### PR TITLE
Add a root name to the repositories config in composer.json

### DIFF
--- a/1.0/installation.md
+++ b/1.0/installation.md
@@ -18,12 +18,18 @@ Once you have purchased a Nova license, you may download a Nova release from the
 First, unzip the contents of the Nova release into a `nova` directory within your application's root directory. Once you have unzipped and placed the Nova source code within the appropriate directory, you are ready to update your `composer.json` file. You should add the following configuration to the file:
 
 ```json
-"repositories": [
-    {
-        "type": "path",
-        "url": "./nova"
-    }
-],
+"repositories": {
+    "laravel/nova":
+        {
+            "type": "path",
+            "url": "./nova"
+        }
+},
+```
+or simply run the following:
+
+```sh
+composer config repositories."laravel/nova" path "/.nova"
 ```
 
 :::warning Hidden Files


### PR DESCRIPTION
Also allows one to add a composer sh command to achieve the same.

I have a view "local" repositories I pull into php projects and having them "namespaces" in the composer.json can be very helpful once they start going into the double digits.   The composer doc's don't offer / suggest this in there examples, but it is required for the command line option.

(Just a suggestion)