### PR TITLE
Clarify where BelongsToMany/HasMany relationships should appear

### DIFF
--- a/1.0/resources/relationships.md
+++ b/1.0/resources/relationships.md
@@ -32,6 +32,8 @@ use Laravel\Nova\Fields\HasMany;
 HasMany::make('Posts')
 ```
 
+When added, a HasMany field can be found/modified on the parent resource's View Details screen.
+
 ## BelongsTo
 
 The `BelongsTo` field corresponds to a `belongsTo` Eloquent relationship. For example, let's assume a `Post` model `belongsTo` a `User` model. We may add the relationship to our `Post` Nova resource like so:
@@ -77,6 +79,8 @@ use Laravel\Nova\Fields\BelongsToMany;
 
 BelongsToMany::make('Roles')
 ```
+
+When added, a BelongsToMany field can be found/modified on the parent resource's View Details screen.
 
 #### Pivot Fields
 


### PR DESCRIPTION
If this is the expected behavior, it should probably be clearer that BelongsToMany relationships will not appear when editing or creating a new resource, only when viewing its details.

If this is not the intended functionality, can be ignored!