### PR TITLE
Changing wording about pivot fields

### DIFF
--- a/1.0/resources/relationships.md
+++ b/1.0/resources/relationships.md
@@ -84,7 +84,7 @@ Once the field has been added to your resource, it will be displayed on the reso
 
 #### Pivot Fields
 
-If your `belongsToMany` relationship interacts with additional "pivot" fields that are stored on the intermediate table of the many-to-many relationship, you may also attach those to your `BelongsToMany` Nova relationship. Once these fields are attached to the relationship field, they will be displayed on the related resource index.
+If your `belongsToMany` relationship interacts with additional "pivot" fields that are stored on the intermediate table of the many-to-many relationship, you may also attach those to your `BelongsToMany` Nova relationship. Once these fields are attached to the relationship field, and the relationship has been defined on both sides, they will be displayed on the related resource index.
 
 For example, let's assume our `User` model `belongsToMany` `Role` models. On our `role_user` intermediate table, let's imagine we have a `notes` field that contains some simple text notes about the relationship. We can attach this pivot field to the `BelongsToMany` field using the `fields` method:
 


### PR DESCRIPTION
Pivot fields only show up when the relationship has been defined on both sides. The documentation makes it seem like this optional. 

I have tried to add information about this, but perhaps the sentence "Of course, it is likely we would also define this field on the inverse of the relationship" should be changed as well.