### PR TITLE
Add field help method

### DIFF
--- a/1.0/resources/fields.md
+++ b/1.0/resources/fields.md
@@ -628,3 +628,11 @@ Text::make('Name')->displayUsing(function ($name) {
     return strtoupper($name);
 })
 ```
+
+### Field Help Text
+
+If you would like to display some text beneath a field, explaining the field requirements or constraints, you can add the `help` method to your field. This method accepts a `string`:
+
+```php
+Text::make('Percent Increase')->help('Field must be a percentage');
+```


### PR DESCRIPTION
Adding the field `help` method in the Field>Customization section of the docs.

This method allows you to display some text beneath and explain any requirements, or any constraints for the field.

```php
Text::make('Percent Increase')->help('Field must be a percentage');
```