### PR TITLE
Correct method than needs calling to always show Trix field content

### DIFF
--- a/1.0/resources/fields.md
+++ b/1.0/resources/fields.md
@@ -579,10 +579,10 @@ use Laravel\Nova\Fields\Trix;
 Trix::make('Biography')
 ```
 
-By default, Trix fields will not display their content when viewing a resource on its detail page. It will be hidden behind a "Show Content" link, that when clicked will reveal the content. You may specify the Trix field should always display its content by calling the `shouldBeExpanded` method on the field itself:
+By default, Trix fields will not display their content when viewing a resource on its detail page. It will be hidden behind a "Show Content" link, that when clicked will reveal the content. You may specify the Trix field should always display its content by calling the `alwaysShow` method on the field itself:
 
 ```php
-Trix::make('Biography')->shouldBeExpanded();
+Trix::make('Biography')->alwaysShow();
 ```
 
 #### File Uploads


### PR DESCRIPTION
This PR corrects the method than needs calling to always show Trix field content.