### PR TITLE
Updates the reference to `shouldBeExpanded()` to `alwaysShow()` as `shouldBeExpanded()` cannot be used in a Field initialisation context

### DIFF
--- a/1.0/resources/fields.md
+++ b/1.0/resources/fields.md
@@ -339,10 +339,10 @@ use Laravel\Nova\Fields\Markdown;
 Markdown::make('Biography')
 ```
 
-By default, Markdown fields will not display their content when viewing a resource on its detail page. It will be hidden behind a "Show Content" link, that when clicked will reveal the content. You may specify the Markdown field should always display its content by calling the `shouldBeExpanded` method on the field itself:
+By default, Markdown fields will not display their content when viewing a resource on its detail page. It will be hidden behind a "Show Content" link, that when clicked will reveal the content. You may specify the Markdown field should always display its content by calling the `alwaysShow` method on the field itself:
 
 ```php
-Markdown::make('Biography')->shouldBeExpanded();
+Markdown::make('Biography')->alwaysShow();
 ```
 
 ### Number Field


### PR DESCRIPTION
Calling shouldBeExpanded() on an initialised Markdown field (as per docs) returns a boolean, causing an 'call to member function authorize() on boolean' error. Looking at the code, it seems `alwaysShow()` should be called instead to force Markdown fields to render on view (as this returns `$this` instead of a boolean). This pull request reflects that.