### PR TITLE
Update code examples for filters with changes in v1.1.8

### DIFF
--- a/1.0/filters/defining-filters.md
+++ b/1.0/filters/defining-filters.md
@@ -36,7 +36,9 @@ class UserType extends Filter
      */
     public function apply(Request $request, $query, $value)
     {
-        return $query->where('type', $value);
+        if ($value) {
+            return $query->where('type', $value);
+        }
     }
 
     /**
@@ -100,8 +102,10 @@ class UserType extends BooleanFilter
         // dump($value);
         // ['admin' => true/false, 'editor' => true/false]
 
-        return $query->where('is_admin', $value['admin'])
-                     ->where('is_editor', $value['editor']);
+        if ($value) {
+            return $query->where('is_admin', $value['admin'])
+                         ->where('is_editor', $value['editor']);
+        }
     }
 
     /**
@@ -163,7 +167,9 @@ class BirthdayFilter extends DateFilter
      */
     public function apply(Request $request, $query, $value)
     {
-        return $query->where('birthday', '<=', Carbon::parse($value));
+        if ($value) {
+            return $query->where('birthday', '<=', Carbon::parse($value));
+        }
     }
 }
 ```


### PR DESCRIPTION
- In v1.1.8, a select query is made using an empty value, even if no filter is applied. Eg: `select * from deals where vendor = ''`

- This is breaking the index views for many including me. An ongoing open discussion about the same issue: https://github.com/laravel/nova-issues/issues/1009

- As pointed out in https://github.com/laravel/nova-issues/issues/1015 by David to check if the value is empty in your filter, this PR updates the code examples in the docs accordingly.

PS: This check was not required in versions prior to v1.1.8