### PR TITLE
Fix breakpoint min 720

### DIFF
--- a/.vuepress/style.styl
+++ b/.vuepress/style.styl
@@ -16,7 +16,7 @@ h2
 
 /* Page
 -----------------------------------------------------------------------------*/
-@media (min-width 719px)
+@media (min-width 720px)
   .page
     padding-left 13.75rem
 


### PR DESCRIPTION
If you go to 719px with browser, we see that padding-left on page is apply but sidebar is collapse to left. So, you need to media queries on 720px min for this padding.