### PR TITLE
Remove CSS section

### DIFF
--- a/2.0/customization/frontend.md
+++ b/2.0/customization/frontend.md
@@ -2,10 +2,6 @@
 
 [[toc]]
 
-## CSS
-
-Nova utilizes the [Tailwind.css](https://tailwindcss.com/docs/what-is-tailwind/) utility library for all styling. So, you are free to leverage all Tailwind features and classes that are needed by your custom components.
-
 ## JavaScript
 
 When building custom Nova tools, resource tools, cards, and fields, you may use a variety of helpers that are globally available to your JavaScript components.


### PR DESCRIPTION
It's not the case that nova has all of tailwind, so this shouldn't be in the documentation.