### PR TITLE
Add tip box to clarify number field constraints

### DIFF
--- a/2.0/resources/fields.md
+++ b/2.0/resources/fields.md
@@ -392,6 +392,11 @@ You may use the `min`, `max`, and `step` methods to set their corresponding attr
 Number::make('price')->min(1)->max(1000)->step(0.01)
 ```
 
+:::tip Step value
+
+By default, the HTML number input element will only accept integers (or integer increments of the initial value). The step value can be set to the desired precision, or to the string `any` to accept any numerical value.
+:::
+
 ### Password Field
 
 The `Password` field provides an `input` control with a `type` attribute of `password`:


### PR DESCRIPTION
Currently the docs don't mention the validation constraints of using the number input and `step()` method which can lead to confusion (e.g. https://github.com/laravel/nova-issues/issues/103).

Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#step
