### PR TITLE
Date field updated to DateTime

### DIFF
--- a/2.0/resources/fields.md
+++ b/2.0/resources/fields.md
@@ -272,7 +272,7 @@ DateTime::make('Updated At')->hideFromIndex()
 You may customize the display format of your `DateTime` fields using the `format` method. The format must be a format supported by [Moment.js](https://momentjs.com/docs/#/parsing/string-format/):
 
 ```php
-Date::make('Created At')->format('DD MMM YYYY'),
+DateTime::make('Created At')->format('DD MMM YYYY'),
 ```
 
 ### File Field


### PR DESCRIPTION
This PR simply changes the reference to `Date` within the DateTime field section to `DateTime` under the `format()` instructions.