### PR TITLE
KeyValue anchor reference fixed

### DIFF
--- a/2.0/resources/fields.md
+++ b/2.0/resources/fields.md
@@ -129,7 +129,7 @@ Nova ships with a variety of field types. So, let's explore all of the available
 - [Heading](#heading-field)
 - [ID](#id-field)
 - [Image](#image-field)
-- [KeyValue](#key-value-field)
+- [KeyValue](#keyvalue-field)
 - [Markdown](#markdown-field)
 - [Number](#number-field)
 - [Password](#password-field)


### PR DESCRIPTION
The link anchor reference was incorrect. This PR fixes the reference so the link works properly.