### PR TITLE
Match docs background color to homepage

### DIFF
--- a/.vuepress/style.styl
+++ b/.vuepress/style.styl
@@ -1,5 +1,5 @@
 body
-  background-color #eee
+  background-color #eef1f4
   font-family "Nunito"
 
 /* Headings


### PR DESCRIPTION
Going from the homepage to the docs feels ever so slightly off brand because of the blue coolness
I also think the blue vs grey on the docs makes it feel a little more fun / playful / light

| before | after |
| - | - |
| ![before](https://user-images.githubusercontent.com/29180903/57265586-5eae1780-7046-11e9-8503-0818f71c26d1.png) | ![after](https://user-images.githubusercontent.com/29180903/57265591-61a90800-7046-11e9-8186-d89103d6ebf1.png) |

