### PR TITLE
Adds addTypes for Badge field.

### DIFF
--- a/2.0/resources/fields.md
+++ b/2.0/resources/fields.md
@@ -186,6 +186,14 @@ Badge::make('Status')->types([
 ]);
 ```
 
+If you would only like to add one or more types to the built-in ones you can use the `addTypes` method:
+
+```php
+Badge::make('Status')->addTypes([
+    'draft' => 'custom classes',
+]);
+```
+
 By default the `Badge` field is not shown on the edit or update views. If you wish to modify the value represented by the `Badge` field on your edit forms, use another field in combination with the `onlyOnForms` field option.
 
 ### Boolean Field


### PR DESCRIPTION
Related to #178.

This PR https://github.com/laravel/nova/pull/453 added a `addTypes` method to the `Badge` field.
Updated the docs for this.

Should these changes (and #178) also be merged into the master branch to become visible the nova docs site?
