### PR TITLE
Typo Fixes for explicitely

### DIFF
--- a/1.0/resources/fields.md
+++ b/1.0/resources/fields.md
@@ -704,7 +704,7 @@ Text::make('Status', function () {
 
 ### Nullable fileds
 
-By default, Nova attempts to store all fields with a value, however, there are times where you'd like to explicitely direct Nova to store a `null` value when the field is empty. To do this, you may use the `nullable` method on your field:
+By default, Nova attempts to store all fields with a value, however, there are times where you'd like to explicitly direct Nova to store a `null` value when the field is empty. To do this, you may use the `nullable` method on your field:
 
 ```php
 Text::make('Position')->nullable();

--- a/2.0/resources/fields.md
+++ b/2.0/resources/fields.md
@@ -799,7 +799,7 @@ Text::make('Email')->readonly(function ($request) {
 
 ### Nullable Fields
 
-By default, Nova attempts to store all fields with a value, however, there are times where you'd like to explicitely direct Nova to store a `null` value when the field is empty. To do this, you may use the `nullable` method on your field:
+By default, Nova attempts to store all fields with a value, however, there are times where you'd like to explicitly direct Nova to store a `null` value when the field is empty. To do this, you may use the `nullable` method on your field:
 
 ```php
 Text::make('Position')->nullable();


### PR DESCRIPTION
Changed "explicitely" to "explicitly" in v.1 and v.2 `fields.md` files.