### PR TITLE
Add 3rd Party Package Installation information

### DIFF
--- a/2.0/installation.md
+++ b/2.0/installation.md
@@ -218,6 +218,20 @@ To ensure Nova's assets are updated when a new version is downloaded, you may ad
 }
 ```
 
+## 3rd Party Package Installation
+
+Offering Nova support to 3rd party Laravel packages is perfectly acceptable. Distributing the Nova source code in your package is not permitted. Distributing your own Nova "resources" & other custom Nova components is permiitted. For example: a "Laravel comments" package can advertise "Nova Support", meaning the package automatically registers a `Comment` resource for managing comments.
+
+Check that Nova exists & add resources in your package's service provider like so:
+
+```php
+if (class_exists(\Laravel\Nova\Nova::class)) {
+    \Laravel\Nova\Nova::resources([
+        \Package\Nova\Comment::class,
+    ]);
+}
+```
+
 ## Bug Reports
 
 If you discover a bug in Laravel Nova, please open an issue on the [Nova issues GitHub repository](https://github.com/laravel/nova-issues).


### PR DESCRIPTION
I've seen a few questions in chat & on product hunt asking  about adding "Nova Support"
One reply even suggested that they can't sell their package with Nova support.
So I made an attempt to differentiate between sharing Nova & Nova resources.
Would be awesome to see `Nova Support` in more packages