### PR TITLE
docs: update upgrade docs for laravel 6

### DIFF
--- a/2.0/installation.md
+++ b/2.0/installation.md
@@ -146,11 +146,11 @@ composer config http-basic.nova.laravel.com ${NOVA_USERNAME} ${NOVA_PASSWORD}
 
 ## Upgrade Guide
 
-Nova 2.0 is primarily a maintenance release to provide compatibility with Laravel 5.8. Nova 2.0 should **only** be used with Laravel 5.8, as it is not compatible with previous releases of Laravel.
+Nova 2.0 is primarily a maintenance release to provide compatibility with Laravel 5.8 or greater. Nova 2.0 should **only** be used with Laravel 5.8 or greater, as it is not compatible with previous releases of Laravel.
 
 Update your `laravel/nova` dependency to ~2.0 in your `composer.json` file and run `composer update` followed by `php artisan migrate`.
 
-Your Nova resources will not require any changes during this upgrade; however, you should review the entire [Laravel 5.8 upgrade guide](https://laravel.com/docs/5.8/upgrade).
+Your Nova resources will not require any changes during this upgrade; however, you should review the [Laravel 5.8 upgrade guide](https://laravel.com/docs/5.8/upgrade) and the [Laravel 6.x upgrade guide](https://laravel.com/docs/6.x/upgrade).
 
 ## Customizing Nova's Authentication Guard
 

--- a/2.0/installation.md
+++ b/2.0/installation.md
@@ -150,7 +150,7 @@ Nova 2.0 is primarily a maintenance release to provide compatibility with Larave
 
 Update your `laravel/nova` dependency to ~2.0 in your `composer.json` file and run `composer update` followed by `php artisan migrate`.
 
-Your Nova resources will not require any changes during this upgrade; however, you should review the [Laravel 5.8 upgrade guide](https://laravel.com/docs/5.8/upgrade) and the [Laravel 6.x upgrade guide](https://laravel.com/docs/6.x/upgrade).
+Your Nova resources will not require any changes during this upgrade; however, you should review the [Laravel upgrade guide](https://laravel.com/docs/upgrade).
 
 ## Customizing Nova's Authentication Guard
 


### PR DESCRIPTION
Reading the upgrade docs it seems the suggest that 2.0 only works with Laravel 5.8 (when it's been [supported for a while](https://nova.laravel.com/releases))