### PR TITLE
Commas instead of semicolons

### DIFF
--- a/2.0/resources/fields.md
+++ b/2.0/resources/fields.md
@@ -32,7 +32,7 @@ public function fields(Request $request)
 As noted above, Nova will "snake case" the displayable name of the field to determine the underlying database column. However, if necessary, you may pass the column name as the second argument to the field's `make` method:
 
 ```php
-Text::make('Name', 'name_column');
+Text::make('Name', 'name_column'),
 ```
 
 ## Showing / Hiding Fields
@@ -57,7 +57,7 @@ The following methods may be used to show / hide fields based on the display con
 You may chain any of these methods onto your field's definition in order to instruct Nova where the field should be displayed:
 
 ```php
-Text::make('Name')->hideFromIndex();
+Text::make('Name')->hideFromIndex(),
 ```
 
 Alternatively, you may pass a callback to the following methods.
@@ -76,7 +76,7 @@ For `show*` methods, the field will be displayed if the given callback returns `
 ```php
 Text::make('Name')->showOnIndex(function () {
     return $this->name === 'Taylor Otwell';
-});
+}),
 ```
 
 For `hide*` methods, the field will be hidden if the given callback returns `true`:
@@ -84,7 +84,7 @@ For `hide*` methods, the field will be hidden if the given callback returns `tru
 ```php
 Text::make('Name')->hideFromIndex(function () {
     return $this->name === 'Taylor Otwell';
-});
+}),
 ```
 
 ## Field Panels
@@ -148,7 +148,7 @@ Panels with a limit set will display a **Show All Fields** button which shows al
 When attaching a field to a resource, you may use the `sortable` method to indicate that the resource index may be sorted by the given field:
 
 ```php
-Text::make('Name', 'name_column')->sortable();
+Text::make('Name', 'name_column')->sortable(),
 ```
 
 ## Field Types
@@ -193,7 +193,7 @@ The `Avatar` field extends the [Image field](#image-field) and accepts the same 
 ```php
 use Laravel\Nova\Fields\Avatar;
 
-Avatar::make('Avatar');
+Avatar::make('Avatar'),
 ```
 
 If a resource contains an `Avatar` field, that field will be displayed next to the resource's title when the resource is displayed in search results:
@@ -220,7 +220,7 @@ By default, the `Badge` field supports four `Resource` values: `info`, `success`
 Badge::make('Status')->map([
     'draft' => 'danger',
     'published' => 'success',
-]);
+]),
 ```
 
 You can also use `types` to completely replace the built-in types and their associate CSS classes:
@@ -228,8 +228,8 @@ You can also use `types` to completely replace the built-in types and their asso
 ```php
 Badge::make('Status')->types([
     'draft' => 'custom classes', // Classes can be a string
-    'published' => ['custom', 'class',] // Classes can also be an array
-]);
+    'published' => ['custom', 'class'] // Classes can also be an array
+]),
 ```
 
 To supplement the built-in types you may use the `addTypes` method:
@@ -237,7 +237,7 @@ To supplement the built-in types you may use the `addTypes` method:
 ```php
 Badge::make('Status')->addTypes([
     'draft' => 'custom classes',
-]);
+]),
 ```
 
 By default the `Badge` field is not shown on the edit or update views. If you wish to modify the value represented by the `Badge` field on your edit forms, use another field in combination with the `onlyOnForms` field option.
@@ -249,7 +249,7 @@ The `Boolean` field may be used to represent a boolean / "tiny integer" column i
 ```php
 use Laravel\Nova\Fields\Boolean;
 
-Boolean::make('Active');
+Boolean::make('Active'),
 ```
 
 #### Customizing True / False Values
@@ -258,8 +258,8 @@ If you are using values other than `true`, `false`, `1`, or `0` to represent "tr
 
 ```php
 Boolean::make('Active')
-        ->trueValue('On')
-        ->falseValue('Off');
+    ->trueValue('On')
+    ->falseValue('Off'),
 ```
 
 ### Boolean Group Field
@@ -293,7 +293,7 @@ The `Code` fields provides a beautiful code editor within your Nova administrati
 ```php
 use Laravel\Nova\Fields\Code;
 
-Code::make('Snippet');
+Code::make('Snippet'),
 ```
 
 :::tip Code Fields On The Index
@@ -306,7 +306,7 @@ By default, Nova will never display a `Code` field on a resource index listing.
 If you intend to use a given `Code` field instance to only edit JSON, you may chain the `json` method onto your field definition:
 
 ```php
-Code::make('Options')->json();
+Code::make('Options')->json(),
 ```
 
 #### Syntax Highlighting
@@ -314,7 +314,7 @@ Code::make('Options')->json();
 You may customize the language syntax highlighting of the `Code` field using the `language` method:
 
 ```php
-Code::make('Snippet')->language('php');
+Code::make('Snippet')->language('php'),
 ```
 
 The `Code` field's currently supported languages are:
@@ -338,7 +338,7 @@ The `Country` field generates a `Select` field containing a list of the world's 
 ```php
 use Laravel\Nova\Fields\Country;
 
-Country::make('Country', 'country_code');
+Country::make('Country', 'country_code'),
 ```
 
 ### Currency Field
@@ -348,9 +348,9 @@ The `Currency` field generates a `Number` field that is automatically displayed 
 ```php
 use Laravel\Nova\Fields\Currency;
 
-Currency::make('Price')
+Currency::make('Price'),
 
-Currency::make('Price')->format('%.2n');
+Currency::make('Price')->format('%.2n'),
 ```
 
 ### Date Field
@@ -360,7 +360,7 @@ The `Date` field may be used to store a date value (without time). For more info
 ```php
 use Laravel\Nova\Fields\Date;
 
-Date::make('Birthday');
+Date::make('Birthday'),
 ```
 
 #### Date Formats
@@ -373,7 +373,7 @@ Date::make('Birthday')->format('DD MMM'),
 
 To customize the display format used for the JavaScript date picker widget, you can use the `pickerFormat` method:
 
-```
+```php
 Date::make('Birthday')->pickerFormat('d.m.Y'),
 ```
 
@@ -394,14 +394,14 @@ The `DateTime` field may be used to store a date-time value. For more informatio
 ```php
 use Laravel\Nova\Fields\DateTime;
 
-DateTime::make('Updated At')->hideFromIndex();
+DateTime::make('Updated At')->hideFromIndex(),
 ```
 
 You may customize the display format of your `DateTime` fields using the `format` method. The format must be a format supported by [Moment.js](https://momentjs.com/docs/#/parsing/string-format/):
 
 To customize the display format used for the JavaScript date picker widget, you can use the `pickerFormat` method:
 
-```
+```php
 Date::make('Birthday')->pickerFormat('d.m.Y'),
 ```
 
@@ -418,7 +418,7 @@ To learn more about defining file fields and handling uploads, check out the add
 ```php
 use Laravel\Nova\Fields\File;
 
-File::make('Attachment');
+File::make('Attachment'),
 ```
 
 ### Gravatar Field
@@ -431,10 +431,10 @@ By default, the Gravatar URL will be generated based on the value of the model's
 use Laravel\Nova\Fields\Gravatar;
 
 // Using the "email" column...
-Gravatar::make()
+Gravatar::make(),
 
 // Using the "email_address" column...
-Gravatar::make('Avatar', 'email_address');
+Gravatar::make('Avatar', 'email_address'),
 ```
 
 You may use the `squared` method to display the image's thumbnail with squared edges. Additionally, you may use the `rounded` method to display its thumbnails with fully-rounded edges.
@@ -446,13 +446,13 @@ The `Heading` field does not correspond to any column in your application's data
 ![Heading Field](./img/heading-field.png)
 
 ```php
-Heading::make('Meta');
+Heading::make('Meta'),
 ```
 
 If you need to render HTML content within the `Heading` field, use the `asHtml` method:
 
 ```php
-Heading::make('<p class="text-danger">* All fields are required.</p>')->asHtml();
+Heading::make('<p class="text-danger">* All fields are required.</p>')->asHtml(),
 ```
 
 ::: tip Headings And Indexes
@@ -468,13 +468,13 @@ The `ID` field represents the primary key of your resource's database table. Typ
 use Laravel\Nova\Fields\ID;
 
 // Using the "id" column...
-ID::make()
+ID::make(),
 
 // Using the "id_column" column...
-ID::make('ID', 'id_column')
+ID::make('ID', 'id_column'),
 
 // Resolve BIGINT ID fields
-ID::make()->asBigInt();
+ID::make()->asBigInt(),
 ```
 
 ### Image Field
@@ -484,13 +484,13 @@ The `Image` field extends the [File field](#file-field) and accepts the same opt
 ```php
 use Laravel\Nova\Fields\Image;
 
-Image::make('Photo');
+Image::make('Photo'),
 ```
 
 By default, the `Image` field allows the user to download the linked file. To disable this you can use the `disableDownload` method on the field definition:
 
 ```php
-Image::make('Photo')->disableDownload();
+Image::make('Photo')->disableDownload(),
 ```
 
 You may use the `squared` method to display the image's thumbnail with squared edges. Additionally, you may use the `rounded` method to display its thumbnails with fully-rounded edges.
@@ -507,7 +507,7 @@ The `KeyValue` field provides a convenient interface to edit _flat_, key-value d
 ```php
 use Laravel\Nova\Fields\KeyValue;
 
-KeyValue::make('Meta')->rules('json');
+KeyValue::make('Meta')->rules('json'),
 ```
 
 This would give you an interface similar to this:
@@ -526,13 +526,13 @@ The `Markdown` field provides a WYSIWYG Markdown editor for its associated field
 ```php
 use Laravel\Nova\Fields\Markdown;
 
-Markdown::make('Biography');
+Markdown::make('Biography'),
 ```
 
 By default, Markdown fields will not display their content when viewing a resource on its detail page. It will be hidden behind a "Show Content" link, that when clicked will reveal the content. You may specify the Markdown field should always display its content by calling the `alwaysShow` method on the field itself:
 
 ```php
-Markdown::make('Biography')->alwaysShow();
+Markdown::make('Biography')->alwaysShow(),
 ```
 
 ### Number Field
@@ -542,13 +542,13 @@ The `Number` field provides an `input` control with a `type` attribute of `numbe
 ```php
 use Laravel\Nova\Fields\Number;
 
-Number::make('price');
+Number::make('price'),
 ```
 
 You may use the `min`, `max`, and `step` methods to set their corresponding attributes on the generated `input` control:
 
 ```php
-Number::make('price')->min(1)->max(1000)->step(0.01);
+Number::make('price')->min(1)->max(1000)->step(0.01),
 ```
 
 ### Password Field
@@ -558,7 +558,7 @@ The `Password` field provides an `input` control with a `type` attribute of `pas
 ```php
 use Laravel\Nova\Fields\Password;
 
-Password::make('Password');
+Password::make('Password'),
 ```
 
 The `Password` field will automatically preserve the password that is currently stored in the database if the incoming password field is empty. Therefore, a typical password field definition might look like the following:
@@ -627,7 +627,7 @@ protected function addressFields()
 By default, the `Place` field will search all addresses around the world. If you would like to limit the countries included in the search, you may use the `countries` method:
 
 ```php
-Place::make('Address', 'address_line_1')->countries(['US', 'CA']);
+Place::make('Address', 'address_line_1')->countries(['US', 'CA']),
 ```
 
 #### City Search
@@ -635,7 +635,7 @@ Place::make('Address', 'address_line_1')->countries(['US', 'CA']);
 If you intend to use the `Place` field to search for cities instead of addresses, you may use the `onlyCities` method to instruct the field to only list cities in its results:
 
 ```php
-Place::make('City')->onlyCities();
+Place::make('City')->onlyCities(),
 ```
 
 :::tip City Auto-Completion
@@ -665,7 +665,7 @@ Place::make('Address', 'address_line_1')
     ->suburb('suburb')
     ->country('country_code')
     ->latitude('latitude')
-    ->longitude('longitude');
+    ->longitude('longitude'),
 ```
 
 ### Select Field
@@ -679,7 +679,7 @@ Select::make('Size')->options([
     'S' => 'Small',
     'M' => 'Medium',
     'L' => 'Large',
-]);
+]),
 ```
 
 On the resource index and detail screens, the `Select` field's "key" value will be displayed. If you would like to display the labels instead, you may use the `displayUsingLabels` method:
@@ -689,7 +689,7 @@ Select::make('Size')->options([
     'S' => 'Small',
     'M' => 'Medium',
     'L' => 'Large',
-])->displayUsingLabels();
+])->displayUsingLabels(),
 ```
 
 You may also display select options in groups:
@@ -700,7 +700,7 @@ Select::make('Size')->options([
     'MM' => ['label' => 'Medium', 'group' => 'Men Sizes'],
     'WS' => ['label' => 'Small', 'group' => 'Women Sizes'],
     'WM' => ['label' => 'Medium', 'group' => 'Women Sizes'],
-])->displayUsingLabels();
+])->displayUsingLabels(),
 ```
 
 If your options are dynamically generated you may pass a `Closure`:
@@ -712,7 +712,7 @@ Select::make('Size')->options(function () {
         Size::MEDIUM => Size::MAX_SIZE === SIZE_MEDIUM ? 'Medium' : null,
         Size::LARGE => Size::MAX_SIZE === SIZE_LARGE ? 'Large' : null,
     ]);
-});
+}),
 ```
 
 ### Status Field
@@ -727,8 +727,8 @@ The `loadingWhen` and `failedWhen` methods may be used to instruct the field whi
 use Laravel\Nova\Fields\Status;
 
 Status::make('Status')
-        ->loadingWhen(['waiting', 'running'])
-        ->failedWhen(['failed']);
+    ->loadingWhen(['waiting', 'running'])
+    ->failedWhen(['failed']),
 ```
 
 ### Text Field
@@ -738,7 +738,7 @@ The `Text` field provides an `input` control with a `type` attribute of `text`:
 ```php
 use Laravel\Nova\Fields\Text;
 
-Text::make('Name');
+Text::make('Name'),
 ```
 
 Text fields may be customized further by setting any attribute on the field. This can be done by calling the `withMeta` methods and passing in a valid `extraAttributes` value:
@@ -746,7 +746,7 @@ Text fields may be customized further by setting any attribute on the field. Thi
 ```php
 Text::make('Name')->withMeta(['extraAttributes' => [
     'placeholder' => 'David Hemphill']
-]);
+]),
 ```
 
 #### Formatting Text As Links
@@ -758,7 +758,7 @@ Text::make('Twitter Profile', function () {
     $username = $this->twitterUsername;
 
     return "<a href='https://twitter.com/{$username}'>@{$username}</a>";
-})->asHtml();
+})->asHtml(),
 ```
 
 ### Textarea Field
@@ -768,19 +768,19 @@ The `Textarea` field provides a `textarea` control:
 ```php
 use Laravel\Nova\Fields\Textarea;
 
-Textarea::make('Biography');
+Textarea::make('Biography'),
 ```
 
 By default, Textarea fields will not display their content when viewing a resource on its detail page. It will be hidden behind a "Show Content" link, that when clicked will reveal the content. You may specify the Textarea field should always display its content by calling the `alwaysShow` method on the field itself:
 
 ```php
-Textarea::make('Biography')->alwaysShow();
+Textarea::make('Biography')->alwaysShow(),
 ```
 
 You may also specify the textarea's height by calling the `rows` method on the field:
 
 ```php
-Textarea::make('Excerpt')->rows(3);
+Textarea::make('Excerpt')->rows(3),
 ```
 
 Textarea fields may be customized further by setting any attribute on the field. This can be done by calling the `withMeta` methods and passing in a valid `extraAttributes` value:
@@ -788,7 +788,7 @@ Textarea fields may be customized further by setting any attribute on the field.
 ```php
 Textarea::make('Excerpt')->withMeta(['extraAttributes' => [
     'placeholder' => 'Make it less than 50 characters']
-]);
+]),
 ```
 
 ### Timezone Field
@@ -798,7 +798,7 @@ The `Timezone` field generates a `Select` field containing a list of the world's
 ```php
 use Laravel\Nova\Fields\Timezone;
 
-Timezone::make('Timezone');
+Timezone::make('Timezone'),
 ```
 
 ### Trix Field
@@ -808,13 +808,13 @@ The `Trix` field provides a [Trix editor](https://github.com/basecamp/trix) for 
 ```php
 use Laravel\Nova\Fields\Trix;
 
-Trix::make('Biography');
+Trix::make('Biography'),
 ```
 
 By default, Trix fields will not display their content when viewing a resource on its detail page. It will be hidden behind a "Show Content" link, that when clicked will reveal the content. You may specify the Trix field should always display its content by calling the `alwaysShow` method on the field itself:
 
 ```php
-Trix::make('Biography')->alwaysShow();
+Trix::make('Biography')->alwaysShow(),
 ```
 
 #### File Uploads
@@ -824,7 +824,7 @@ If you would like to allow users to drag-and-drop photos into the Trix field, ch
 ```php
 use Laravel\Nova\Fields\Trix;
 
-Trix::make('Biography')->withFiles('public');
+Trix::make('Biography')->withFiles('public'),
 ```
 
 In addition, you should define two database tables to store pending and persisted Trix uploads. To do so, create a migration with the following table definitions:
@@ -858,7 +858,7 @@ use Laravel\Nova\Trix\PruneStaleAttachments;
 
 $schedule->call(function () {
     (new PruneStaleAttachments)();
-})->daily();
+})->daily(),
 ```
 
 ## Computed Fields
@@ -868,7 +868,7 @@ In addition to displaying fields that are associated with columns in your databa
 ```php
 Text::make('Name', function () {
     return $this->first_name.' '.$this->last_name;
-});
+}),
 ```
 
 :::tip Model Attribute Access
@@ -883,7 +883,7 @@ Text::make('Status', function () {
     return view('partials.status', [
         'is_passing' => $this->isPassing(),
     ])->render();
-})->asHtml();
+})->asHtml(),
 ```
 
 ## Customization
@@ -893,7 +893,7 @@ Text::make('Status', function () {
 There are times where you may want to allow the user to only create and update certain fields on a resource. You can do this by using the `readonly` method on the field, which will disable the field's corresponding input:
 
 ```php
-Text::make('Email')->readonly(optional($this->resource)->trashed());
+Text::make('Email')->readonly(optional($this->resource)->trashed()),
 ```
 
 You may also pass a `Closure` to the `readonly` method. It will receive the current `NovaRequest` as the first argument:
@@ -947,17 +947,17 @@ Text::make('Email')->required(function ($request) {
 By default, Nova attempts to store all fields with a value, however, there are times where you'd like to explicitly direct Nova to store a `null` value when the field is empty. To do this, you may use the `nullable` method on your field:
 
 ```php
-Text::make('Position')->nullable();
+Text::make('Position')->nullable(),
 ```
 
 You may also set which values should be interpreted as a `null` value using the `nullValues` method:
 
 ```php
-Text::make('Position')->nullable()->nullValues(['', '0', 'null']);
+Text::make('Position')->nullable()->nullValues(['', '0', 'null']),
 
 Text::make('Position')->nullable()->nullValues(function ($value) {
     return $value == '' || $value == 'null' || (int)$value === 0;
-});
+}),
 ```
 
 ### Field Help Text
@@ -967,7 +967,7 @@ If you would like to place "help" text beneath a field, you may use the `help` m
 ```php
 Text::make('Tax Rate')->help(
     'The tax rate to be applied to the sale'
-);
+),
 ```
 
 You may also use HTML when defining your help text:
@@ -975,11 +975,11 @@ You may also use HTML when defining your help text:
 ```php
 Text::make('First Name')->help(
     '<a href="#">External Link</a>'
-);
+),
 
 Text::make('Last Name')->help(
     view('partials.help-text', ['name' => $this->name])->render()
-);
+),
 ```
 
 ### Field Stacking
@@ -987,7 +987,7 @@ Text::make('Last Name')->help(
 By default, Nova displays fields next to their labels, however some fields like "Code", "Markdown", and "Trix" may be better suited to a wider size. Fields can be stacked underneath their label using the `stacked` method:
 
 ```php
-Trix::make('Content')->stacked();
+Trix::make('Content')->stacked(),
 ```
 
 ### Field Text Alignment
@@ -995,7 +995,7 @@ Trix::make('Content')->stacked();
 You may change the text alignment of fields by using the `textAlign` method:
 
 ```php
-Text::make('Phone Number')->textAlign('left');
+Text::make('Phone Number')->textAlign('left'),
 ```
 
 The following alignments are valid:
@@ -1011,7 +1011,7 @@ The `resolveUsing` method allows you to customize how a field is formatted after
 ```php
 Text::make('Name')->resolveUsing(function ($name) {
     return strtoupper($name);
-});
+}),
 ```
 
 If you would like to customize how a field is formatted only when it is displayed on a resource's "index" or "detail" screen, you may use the `displayUsing` method. Like the `resolveUsing` method, this method accepts a single callback:
@@ -1019,5 +1019,5 @@ If you would like to customize how a field is formatted only when it is displaye
 ```php
 Text::make('Name')->displayUsing(function ($name) {
     return strtoupper($name);
-});
+}),
 ```


### PR DESCRIPTION
This PR changes a few things in this documentation.

1. Since Fields are most commonly used within the array returned by `fields()` inside of a Resource, I've updated all field references to end with a comma instead of a semicolon.
2. Minor formatting changes on number of spaces before a chained element on a new line.
3. Added `php` as code type for a couple code blocks in the markup.