### PR TITLE
Update installation.md with composer commands

### DIFF
--- a/2.0/installation.md
+++ b/2.0/installation.md
@@ -116,7 +116,7 @@ Next, you may either manually add `laravel/nova` to your list of required packag
 },
 ```
 
-and subsequently, once your `composer.json` file has been updated, run the `composer update` command in your console terminal:
+And subsequently, once your `composer.json` file has been updated, run the `composer update` command in your console terminal:
 
 ```bash
 composer update

--- a/2.0/installation.md
+++ b/2.0/installation.md
@@ -82,7 +82,14 @@ That's it! Next, you may navigate to your application's `/nova` path in your bro
 
 ## Installing Nova Via Composer
 
-Instead of downloading Zip files containing the Nova source code, you may also install Nova as a typical Nova package via our private Satis repository. To get started, add the Nova repository to your application's `composer.json` file:
+Instead of downloading Zip files containing the Nova source code, you may also install Nova as a typical Nova package via our private Satis repository.
+
+:::tip Package Authentication
+
+Note that installing Nova via Composer will require authentication for the Nova website. These credentials will authenticate your Composer session as having permission to download the Nova source code. To avoid manually typing these credentials upon package installation, you may create a [Composer auth.json file](https://getcomposer.org/doc/articles/http-basic-authentication.md) while optionally using your [API token](https://nova.laravel.com/settings#password) in place of your password.
+:::
+
+To get started, add the Nova repository to your application's `composer.json` file:
 
 ```json
 "repositories": [
@@ -92,8 +99,13 @@ Instead of downloading Zip files containing the Nova source code, you may also i
     }
 ],
 ```
+or by running the command `composer config repositories.nova composer https://nova.laravel.com` in your console terminal:
 
-Next, you may add `laravel/nova` to your list of required packages in your `composer.json` file:
+```bash
+composer config repositories.nova composer https://nova.laravel.com
+```
+
+Next, you may either manually add `laravel/nova` to your list of required packages in your `composer.json` file:
 
 ```json
 "require": {
@@ -104,13 +116,19 @@ Next, you may add `laravel/nova` to your list of required packages in your `comp
 },
 ```
 
-After your `composer.json` file has been updated, run the `composer update` command in your console terminal:
+and subsequently, once your `composer.json` file has been updated, run the `composer update` command in your console terminal:
 
 ```bash
 composer update
 ```
 
-When running `composer update`, you will be prompted to provide your login credentials for the Nova website. These credentials will authenticate your Composer session as having permission to download the Nova source code. To avoid manually typing these credentials, you may create a [Composer auth.json file](https://getcomposer.org/doc/articles/http-basic-authentication.md) while optionally using your [API token](https://nova.laravel.com/settings#password) in place of your password.
+Alternatively, require Laravel Nova by runing the `composer require laravel/nova` command in your console terminal:
+
+```bash
+composer require laravel/nova
+``` 
+
+When requiring Laravel Nova, you will be prompted to provide your login credentials for the Nova website. These credentials will authenticate your Composer session as having permission to download the Nova source code. To avoid manually typing these credentials, you may create a [Composer auth.json file](https://getcomposer.org/doc/articles/http-basic-authentication.md) while optionally using your [API token](https://nova.laravel.com/settings#password) in place of your password.
 
 Finally, run the `nova:install` and `migrate` Artisan commands. The `nova:install` command will install Nova's service provider and public assets within your application:
 
@@ -138,7 +156,7 @@ That's it! Next, you may navigate to your application's `/nova` path in your bro
 
 ## Authenticating Nova in Continuous Integration (CI) Environments
 
-It's not advised to store your `auth.json` file inside your project's version control repository. However, there may be times you wish to download Nova inside a CI environment like [CodeShip](https://codeship.com/). For instance, you may wish to run tests for any custom tools you create. To authenticate Nova in these situations, you can use Composer to set the configuration option inside your CI system's pipeline, injecting environment variables containing your Nova username and password:
+It's not advised to store your `auth.json` file inside your project's version control repository. However, there may be times you wish to download Nova inside a CI environment like [CodeShip](https://codeship.com/). For instance, you may wish to run tests for any custom tools you create. To authenticate Nova in these situations, you can use Composer to set the configuration option inside your CI system's pipeline, injecting environment variables containing either your Nova username and password or optionally using your Nova username and [API token](https://nova.laravel.com/settings#password) in place of your password:
 
 ```sh
 composer config http-basic.nova.laravel.com ${NOVA_USERNAME} ${NOVA_PASSWORD}

--- a/2.0/installation.md
+++ b/2.0/installation.md
@@ -99,7 +99,7 @@ To get started, add the Nova repository to your application's `composer.json` fi
     }
 ],
 ```
-or by running the command `composer config repositories.nova composer https://nova.laravel.com` in your console terminal:
+Alternatively by running the command `composer config repositories.nova composer https://nova.laravel.com` in your console terminal:
 
 ```bash
 composer config repositories.nova composer https://nova.laravel.com


### PR DESCRIPTION
The main purpose of this PR is to clarify a few points regarding installing Nova Via Composer.

- [x] Add composer commands for directly adding the Nova repository and for installing Nova from the command line as an alternative to manually making changes to the `composer.json` file.
- [x] Clarify that the Nova password can be substituted for the Nova API Token (several places).
- [x] Clarify at the beginning of the `Installing Nova Via Composer`-section that authentication is needed when installing Nova Via Composer, instead of having the section below.