### PR TITLE
Way to override connection and queue for actions

### DIFF
--- a/2.0/actions/defining-actions.md
+++ b/2.0/actions/defining-actions.md
@@ -256,22 +256,14 @@ At this time, Nova does not support attaching `File` fields to a queued action. 
 
 #### Customizing The Connection And Queue
 
-You may customize the queue connection and queue name that the action is queued on by defining the `$connection` and `$queue` properties on your action:
+You may customize the queue connection and queue name that the action is queued on by overriding the `$connection` and `$queue` properties in your action constructor:
 
 ```php
-/**
- * The name of the connection the job should be sent to.
- *
- * @var string|null
- */
-public $connection = 'redis';
-
-/**
- * The name of the queue the job should be sent to.
- *
- * @var string|null
- */
-public $queue = 'emails';
+public function __construct()
+{
+    $this->connection = 'redis';
+    $this->queue = 'default';
+}
 ```
 
 ## Action Log


### PR DESCRIPTION
If you set the properties on the action like in the documentation now you get:

`App\Nova\Actions\SomeAction and Illuminate\Bus\Queueable define the same property ($connection) in the composition of App\Nova\Actions\SomeAction. However, the definition differs and is considered incompatible. Class was composed {"userId":1,"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): App\\Nova\\Actions\\SomeAction and Illuminate\\Bus\\Queueable define the same property ($connection) in the composition of App\\Nova\\Actions\\SomeAction. However, the definition differs and is considered incompatible. Class was composed at /home/jelle/Code/boekm3/app/Nova/Actions/SomeAction.php:16)`

Doing it this way worked for me, hope this is the correct way.