### PR TITLE
Added information about casting to an array

### DIFF
--- a/2.0/resources/fields.md
+++ b/2.0/resources/fields.md
@@ -287,6 +287,14 @@ The user will be presented with a grouped set of checkboxes which, when saved, w
 }
 ```
 
+Make sure the database field is casted to an array:
+
+```php
+protected $casts = [
+        'permissions' => 'array'
+];
+```
+
 ### Code Field
 
 The `Code` fields provides a beautiful code editor within your Nova administration panel. Generally, code fields should be attached to `TEXT` database columns. However, you may also attach them to `JSON` database columns:

--- a/2.0/resources/fields.md
+++ b/2.0/resources/fields.md
@@ -287,11 +287,11 @@ The user will be presented with a grouped set of checkboxes which, when saved, w
 }
 ```
 
-Make sure the database field is casted to an array:
+Finally, ensure that your Eloquent attribute is cast to an `array` (or equivalent) within your Eloquent model class:
 
 ```php
 protected $casts = [
-        'permissions' => 'array'
+    'permissions' => 'array'
 ];
 ```
 


### PR DESCRIPTION
Added more documentation about casting to an array because without it an array to string conversion is thrown.

See also https://github.com/laravel/nova-issues/issues/2197