### PR TITLE
fix: link to numbro 1.0 old-format page instead of numbro 2.0 format

### DIFF
--- a/2.0/metrics/defining-metrics.md
+++ b/2.0/metrics/defining-metrics.md
@@ -133,7 +133,7 @@ public function calculate(Request $request)
 }
 ```
 
-To customize the display format, you can use the `format` method. The format must be a format supported by [Numbro](http://numbrojs.com/format.html):
+To customize the display format, you can use the `format` method. The format must be a format supported by [Numbro](http://numbrojs.com/old-format.html):
 
 ```php
 public function calculate(Request $request)

--- a/3.0/metrics/defining-metrics.md
+++ b/3.0/metrics/defining-metrics.md
@@ -133,7 +133,7 @@ public function calculate(Request $request)
 }
 ```
 
-To customize the display format, you can use the `format` method. The format must be a format supported by [Numbro](http://numbrojs.com/format.html):
+To customize the display format, you can use the `format` method. The format must be a format supported by [Numbro](http://numbrojs.com/old-format.html):
 
 ```php
 public function calculate(Request $request)


### PR DESCRIPTION
"Defining metrics" page shows an example format "0,0" and says "The format must be a format supported by Numbro:". 

This "0,0" format isn't found on the linked formats page (probably updated), but it _is_ found on the old-formats page.

At the time of posting, this can be seen at https://nova.laravel.com/docs/3.0/metrics/defining-metrics.html#value-result-formatting

![image](https://user-images.githubusercontent.com/852873/77570302-c51f6c80-6e88-11ea-87d9-1241aaefb0a0.png)