### PR TITLE
update where connection and queue can be defined

### DIFF
--- a/3.0/actions/defining-actions.md
+++ b/3.0/actions/defining-actions.md
@@ -269,22 +269,19 @@ At this time, Nova does not support attaching `File` fields to a queued action. 
 
 #### Customizing The Connection And Queue
 
-You may customize the queue connection and queue name that the action is queued on by defining the `$connection` and `$queue` properties on your action:
+You may customize the queue connection and queue name that the action is queued on by defining the `$connection` and `$queue` properties on your action within constructor:
 
 ```php
-/**
- * The name of the connection the job should be sent to.
- *
- * @var string|null
- */
-public $connection = 'redis';
+class EmailAccountProfile extends Action implements ShouldQueue
+{
+  use InteractsWithQueue, Queueable;
 
-/**
- * The name of the queue the job should be sent to.
- *
- * @var string|null
- */
-public $queue = 'emails';
+  public function __construct()
+  {
+      $this->connection = 'redis';
+      $this->queue = 'emails';
+  }
+}
 ```
 
 ## Action Log

--- a/3.0/actions/defining-actions.md
+++ b/3.0/actions/defining-actions.md
@@ -269,7 +269,7 @@ At this time, Nova does not support attaching `File` fields to a queued action. 
 
 #### Customizing The Connection And Queue
 
-You may customize the queue connection and queue name that the action is queued on by defining the `$connection` and `$queue` properties on your action within constructor:
+You may customize the queue connection and queue name that the action is queued on by setting the `$connection` and `$queue` properties within the action's constructor:
 
 ```php
 class EmailAccountProfile extends Action implements ShouldQueue


### PR DESCRIPTION
Currently, when you'll attempt to do what documentation is suggesting

```
<?php

namespace App\Nova\Actions;

use App\AccountData;
use Illuminate\Bus\Queueable;
use Laravel\Nova\Actions\Action;
use Illuminate\Support\Collection;
use Laravel\Nova\Fields\ActionFields;
use Illuminate\Queue\InteractsWithQueue;
use Illuminate\Contracts\Queue\ShouldQueue;

class Foo extends Action implements ShouldQueue
{
    use InteractsWithQueue, Queueable;

    /**
     * The name of the connection the job should be sent to.
     *
     * @var string|null
     */
    public $connection = 'redis';

    /**
     * The name of the queue the job should be sent to.
     *
     * @var string|null
     */
    public $queue = 'emails';
}
```

you'll get a:

```
Symfony\Component\ErrorHandler\Error\FatalError
App\Nova\Actions\Foo and Illuminate\Bus\Queueable define the same property ($connection) in the composition of App\Nova\Actions\Foo. However, the definition differs and is considered incompatible. Class was composed
```