### PR TITLE
Moved paragraph about Actions visibility

### DIFF
--- a/3.0/actions/defining-actions.md
+++ b/3.0/actions/defining-actions.md
@@ -75,20 +75,6 @@ The most important method of an action is the `handle` method. The `handle` meth
 
 Within the `handle` method, you may perform whatever tasks are necessary to complete the action. You are free to update database records, send emails, call other services, etc. The sky is the limit!
 
-## Action Visibility
-
-By default, actions are visible on both the resource index and detail screens. In addition, inline actions are hidden from the table row's actions dropdown by default. You may designate an action's visibility by setting one of the following methods on the action when defining it:
-
-- `onlyOnIndex`
-- `exceptOnIndex`
-- `showOnIndex`
-- `onlyOnDetail`
-- `exceptOnDetail`
-- `showOnDetail`
-- `onlyOnTableRow`
-- `exceptOnTableRow`
-- `showOnTableRow`
-
 ## Destructive Actions
 
 You may designate an action as destructive or dangerous by having your action class inherit from `Laravel\Nova\Actions\DestructiveAction`. This will change the color of the action's confirm button to red:

--- a/3.0/actions/registering-actions.md
+++ b/3.0/actions/registering-actions.md
@@ -38,6 +38,35 @@ public function actions(Request $request)
 
 Any arguments passed to the `make` method will be passed to the constructor of your action.
 
+## Action Visibility
+
+By default, actions are visible on both the resource index and detail screens. In addition, inline actions are hidden from the table row's actions dropdown by default. You may designate an action's visibility by setting one of the following methods on the action when registering it:
+
+- `onlyOnIndex`
+- `exceptOnIndex`
+- `showOnIndex`
+- `onlyOnDetail`
+- `exceptOnDetail`
+- `showOnDetail`
+- `onlyOnTableRow`
+- `exceptOnTableRow`
+- `showOnTableRow`
+
+```php
+/**
+ * Get the actions available for the resource.
+ *
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
+public function actions(Request $request)
+{
+    return [
+        (new ConsolidateTransaction())->showOnTableRow()
+    ];
+}
+```
+
 ## Authorization
 
 If you would like to only expose a given action to certain users, you may chain the `canSee` method onto your action registration. The `canSee` method accepts a Closure which should return `true` or `false`. The Closure will receive the incoming HTTP request:


### PR DESCRIPTION
Paragraph about Actions visibility was in the wrong section of the docs. Also added an example.