### PR TITLE
Instructions to customize metrics name

### DIFF
--- a/3.0/metrics/defining-metrics.md
+++ b/3.0/metrics/defining-metrics.md
@@ -568,3 +568,19 @@ public function cacheFor()
     return now()->addMinutes(5);
 }
 ```
+
+## Customize Metric Name
+
+By default, Nova will use the class name as the name of your metric. You may customize the name of the metric displayed on the card by overriding the `name` method within your metric class:
+
+```php
+/**
+ * Get the displayable name of the metric
+ *
+ * @return string
+ */
+public function name()
+{
+    return 'Users created';
+}
+```

--- a/3.0/metrics/defining-metrics.md
+++ b/3.0/metrics/defining-metrics.md
@@ -569,9 +569,9 @@ public function cacheFor()
 }
 ```
 
-## Customize Metric Name
+## Customize Metric Names
 
-By default, Nova will use the class name as the name of your metric. You may customize the name of the metric displayed on the card by overriding the `name` method within your metric class:
+By default, Nova will use the metric class name as the displayable name of your metric. You may customize the name of the metric displayed on the metric card by overriding the `name` method within your metric class:
 
 ```php
 /**
@@ -581,6 +581,6 @@ By default, Nova will use the class name as the name of your metric. You may cus
  */
 public function name()
 {
-    return 'Users created';
+    return 'Users Created';
 }
 ```

--- a/3.0/metrics/defining-metrics.md
+++ b/3.0/metrics/defining-metrics.md
@@ -569,7 +569,7 @@ public function cacheFor()
 }
 ```
 
-## Customize Metric Names
+## Customizing Metric Names
 
 By default, Nova will use the metric class name as the displayable name of your metric. You may customize the name of the metric displayed on the metric card by overriding the `name` method within your metric class:
 


### PR DESCRIPTION
Added instructions to modify the name of a metric card (the function is available but not documented)

Text written copied and adapted on the dashboard label customization chapter (https://nova.laravel.com/docs/3.0/customization/dashboards.html#customizing-dashboards)