### PR TITLE
Fixes 2nd parameter usage for Nova.$emit()

### DIFF
--- a/3.0/customization/frontend.md
+++ b/3.0/customization/frontend.md
@@ -38,7 +38,7 @@ The global `Nova` JavaScript object may be used as an event bus by your custom c
 Nova.$on(event, callback)
 Nova.$once(event, callback)
 Nova.$off(event, callback)
-Nova.$emit(event, callback)
+Nova.$emit(event, [...args])
 ```
 
 ### Notifications


### PR DESCRIPTION
Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>