### PR TITLE
Improves field required() method documentation

### DIFF
--- a/3.0/resources/fields.md
+++ b/3.0/resources/fields.md
@@ -1319,7 +1319,7 @@ Nova does this by looking for the `required` rules inside the field's validation
 Text::make('Email')->rules('required'),
 ```
 
-However, you can manually mark the field as required by passing a boolean to the `required` method when defining the field:
+In the event where you have a complex `required` validation, you can manually mark the field as required by passing a boolean to the `required` method when defining the field to indicate "required" indicator in the Nova UI:
 
 ```php
 Text::make('Email')->required(true),
@@ -1328,14 +1328,17 @@ Text::make('Email')->required(true),
 In addition, you may also pass a Closure to the `required` method to determine if the field should be marked as required. The Closure will receive an instance of `NovaRequest`, which you may use to define any complex logic which should be used to evaluate the field's required state:
 
 ```php
-Text::make('Email')->required(function ($request) {
-    return $request->isUpdateOrUpdateAttachedRequest();
-}),
+use Illuminate\Validation\Rule;
 
 Text::make('Email')->required(function ($request) {
     return $this->account_locked !== true;
-}),
+})->rules([Rule::requiredIf($this->account_locked)]),
 ```
+
+:::warning required() limitation
+
+The `required()` method will only indicate "required" indicator to be added to the Nova UI. However you need to always define the related `rules()` to be used for validation.
+:::
 
 ### Nullable Fields
 

--- a/3.0/resources/fields.md
+++ b/3.0/resources/fields.md
@@ -1319,13 +1319,13 @@ Nova does this by looking for the `required` rules inside the field's validation
 Text::make('Email')->rules('required'),
 ```
 
-In the event where you have a complex `required` validation, you can manually mark the field as required by passing a boolean to the `required` method when defining the field to indicate "required" indicator in the Nova UI:
+When you have complex `required` validation requirements, you can manually mark the field as required by passing a boolean to the `required` method when defining the field. This will inform Nova that a "required" indicator should be shown in the UI:
 
 ```php
 Text::make('Email')->required(true),
 ```
 
-In addition, you may also pass a Closure to the `required` method to determine if the field should be marked as required. The Closure will receive an instance of `NovaRequest`, which you may use to define any complex logic which should be used to evaluate the field's required state:
+In addition, you may also pass a Closure to the `required` method to determine if the field should be marked as required. The Closure will receive an instance of `NovaRequest`. You may define any complex logic which should be used to evaluate the field's required state within the Closure:
 
 ```php
 use Illuminate\Validation\Rule;
@@ -1335,9 +1335,9 @@ Text::make('Email')->required(function ($request) {
 })->rules([Rule::requiredIf($this->account_locked)]),
 ```
 
-:::warning required() limitation
+:::warning `required()` Limitations
 
-The `required()` method will only indicate "required" indicator to be added to the Nova UI. However you need to always define the related `rules()` to be used for validation.
+The `required()` method will only add a "required" indicator to the Nova UI. You must still define the related requirement `rules()` that should apply during validation.
 :::
 
 ### Nullable Fields


### PR DESCRIPTION
Fixes laravel/nova-issues#3115

Based on @davidhemphill response in previous discussion:

> To clear up the confusion around this, the required method is intended for situations where the developer has a complex validation requirement (e.g. `required_if:x:7y,z`). The user can pass in a Closure to determine if the required asterisk should be shown. If the user just has a simple required validation rule, they should just use the validation rule since that will add the asterisk as well.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>