### PR TITLE
Update Authorizing Actions Per-Resource to describe full usage.

### DIFF
--- a/3.0/actions/registering-actions.md
+++ b/3.0/actions/registering-actions.md
@@ -136,7 +136,7 @@ public function actions(Request $request)
 
 ## Authorizing Actions Per-Resource
 
-Sometimes it is useful to conditionally display an action based on some state in the resource's underlying model. To do this you can retrieve the resource from the request using `$this->resource` method for Resource and Lens:
+Sometimes it is useful to conditionally display an action based on some state in the resource's underlying model. To do this, you can retrieve the resource via the `resource` property on a resource or lens instance:
 
 ```php
 use Illuminate\Database\Eloquent\Model;
@@ -161,16 +161,6 @@ public function actions(Request $request)
     ];
 }
 ```
-
-:::warning
-
-It's important to remember that actions are not always resolved using an underlying `Model` instance in certain scenario including:
-
-* Running the action, we can check `$request` is an instance of `Laravel\Nova\Http\Requests\ActionRequest`.
-* Getting lists of actions for Resource and Lens where `$this->resource` can be `null` for Resource and `stdClass` for Lens.
-
-Because of this, it's important to check for the existence of the model, instead of assuming one is available.
-:::
 
 #### The `canRun` Method
 

--- a/3.0/actions/registering-actions.md
+++ b/3.0/actions/registering-actions.md
@@ -134,6 +134,11 @@ public function actions(Request $request)
 }
 ```
 
+:::warning Resource Action Model Resolution
+
+It's important to remember that `Resource` actions are not always resolved using an underlying `Model` instance. Because of this, you should check for the existence of the model instead of assuming one is available.
+:::
+
 ## Authorizing Actions Per-Resource
 
 Sometimes it is useful to conditionally display an action based on some state in the resource's underlying model. To do this, you can retrieve the resource via the `resource` property on a resource or lens instance:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/172966/102709432-90d8bf80-42e5-11eb-87d5-fcf13c7c8014.png)

Document added to cover few undocumented behavior:

* When running Action, Nova will always verify that the action both `canSee()`
and `canRun()` are `true`. At the moment we can't change the behavior without causing a breaking change.
* When retrieving available actions for each resource and lens,`$this->resource` can be `null` or `stdClass`. 
* The initial suggested `$request->findModelQuery()` only works on resource but not always on lens, especially when the action is defined only on Lens but not the parent resource).

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>