### PR TITLE
Suggest using --prefer-dist when installing using composer.

### DIFF
--- a/3.0/installation.md
+++ b/3.0/installation.md
@@ -107,7 +107,7 @@ Next, you may add `laravel/nova` to your list of required packages in your `comp
 After your `composer.json` file has been updated, run the `composer update` command in your console terminal:
 
 ```bash
-composer update
+composer update --prefer-dist
 ```
 
 When running `composer update`, you will be prompted to provide your login credentials for the Nova website. These credentials will authenticate your Composer session as having permission to download the Nova source code. To avoid manually typing these credentials, you may create a [Composer auth.json file](https://getcomposer.org/doc/articles/http-basic-authentication.md) while optionally using your [API token](https://nova.laravel.com/settings#password) in place of your password.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/172966/106741854-3a3a0180-6657-11eb-96fb-dff75ba8f86b.png)

If the user previously installs `laravel/nova` via composer but either uses `--prefer-source` or composer fallback to GitHub git clone they will no longer be able to update to a newer version. 

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>