### PR TITLE
Add documentation about $roundingPrecision and $roundingMode properties

### DIFF
--- a/3.0/metrics/defining-metrics.md
+++ b/3.0/metrics/defining-metrics.md
@@ -554,6 +554,8 @@ return $this->result([
 ]);
 ```
 
+For values of float type you can control the rounding precision and rounding mode by overriding the `$roundingPrecision` and `$roundingMode` properties respectively.
+
 ## Caching
 
 Occasionally the calculation of a metric's values can be slow and expensive. For this reason, all Nova metrics contain a `cacheFor` method which allows you to specify the duration the metric result should be cached:


### PR DESCRIPTION
This PR adds documentation about $roundingPrecision and $roundingMode properties to control precision for float values in partition metrics. Background details in this [thread.](https://github.com/laravel/nova-issues/issues/3275)