### PR TITLE
Custom accepted file type docs with comma-separated attributes

### DIFF
--- a/3.0/resources/file-fields.md
+++ b/3.0/resources/file-fields.md
@@ -420,4 +420,4 @@ When using the `acceptedTypes` method, Nova adds the `accepts` attribute to the 
 - `video/*`
 - All media types listed at http://www.iana.org/assignments/media-types/
 
-Since the `acceptedTypes` method only performed client-side validation, you should also validate the file type using server-side validation rules.
+Since the `acceptedTypes` method only performs client-side validation, you should also validate the file type using server-side validation rules.

--- a/3.0/resources/file-fields.md
+++ b/3.0/resources/file-fields.md
@@ -402,3 +402,20 @@ Image::make('Profile Photo')
         return Storage::disk($disk)->download($value, 'avatar');
     }),
 ```
+
+### Customizing Accepted File Types
+
+By default, the `File` field will allow any files to be selected and uploaded. However, you may customize the accepted file types using the `acceptedTypes` method:
+
+```php
+File::make('Disk Image')->acceptedTypes('.dmg,.exe')
+```
+
+When using the `acceptedTypes` method, Nova is adding the `accepts` attribute to the file picker, meaning that all of these media types are valid:
+
+- `.dmg`
+- `.dmg,.exe,.deb`
+- `image/*`
+- `audio/*`
+- `video/*`
+- All media types listed at http://www.iana.org/assignments/media-types/

--- a/3.0/resources/file-fields.md
+++ b/3.0/resources/file-fields.md
@@ -405,13 +405,13 @@ Image::make('Profile Photo')
 
 ### Customizing Accepted File Types
 
-By default, the `File` field will allow any files to be selected and uploaded. However, you may customize the accepted file types using the `acceptedTypes` method:
+By default, the `File` field will allow any files to be selected and uploaded; however, you may customize the accepted file types using the `acceptedTypes` method:
 
 ```php
 File::make('Disk Image')->acceptedTypes('.dmg,.exe')
 ```
 
-When using the `acceptedTypes` method, Nova is adding the `accepts` attribute to the file picker, meaning that all of these media types are valid:
+When using the `acceptedTypes` method, Nova adds the `accepts` attribute to the file input element; therefore, all of the following media types are valid:
 
 - `.dmg`
 - `.dmg,.exe,.deb`
@@ -419,3 +419,5 @@ When using the `acceptedTypes` method, Nova is adding the `accepts` attribute to
 - `audio/*`
 - `video/*`
 - All media types listed at http://www.iana.org/assignments/media-types/
+
+Since the `acceptedTypes` method only performed client-side validation, you should also validate the file type using server-side validation rules.


### PR DESCRIPTION
Added custom accepted file type docs with comma-separated attributes in nova3.X based on 2.x docs