### PR TITLE
Filter `authorizedToRun()` when compiling actions with existing model.

### DIFF
--- a/4.0/actions/registering-actions.md
+++ b/4.0/actions/registering-actions.md
@@ -139,43 +139,6 @@ public function actions(NovaRequest $request)
 It's important to remember that `Resource` actions are not always resolved using an underlying `Model` instance. Because of this, you should check for the existence of the model instead of assuming one is available.
 :::
 
-## Authorizing Actions Per-Resource
-
-Sometimes it is useful to conditionally display an action based on some state in the resource's underlying model. To do this, you can retrieve the resource via the `resource` property on a resource or lens instance:
-
-```php
-use Illuminate\Database\Eloquent\Model;
-use Laravel\Nova\Http\Requests\ActionRequest;
-
-/**
- * Get the actions available for the resource.
- *
- * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
- * @return array
- */
-public function actions(NovaRequest $request)
-{
-    return [
-        (new Actions\CancelTrial)->canSee(function ($request) {
-            if ($request instanceof ActionRequest) {
-                return true;  
-            }
-            
-            if ($this->resource instanceof Model) {
-                return $this->resource->isOnTrial();
-            } elseif (! $request->allResourcesSelected()) {
-                return $request->selectedResources()
-                            ->filter(function ($resource) {
-                                return $resource->isOnTrial();
-                            })->count() === $request->selectedResources()->count();
-            }
-
-            return false;
-        }),
-    ];
-}
-```
-
 #### The `canRun` Method
 
 Sometimes a user may be able to "see" that an action exists but only "run" that action against certain resources. You may use the `canRun` method in conjunction with the `canSee` method to have full control over authorization in this scenario. The callback passed to the `canRun` method receives the incoming HTTP request as well as the model the user would like to run the action against:

--- a/4.0/upgrade.md
+++ b/4.0/upgrade.md
@@ -353,6 +353,63 @@ Nova 4 has introduce shorter key-value map which reduces the length of encoded f
 (new ConsolidateTransaction())->showInline(),
 ```
 
+### Authorizing Actions Per-Resource
+
+In Nova 3, you can conditionally display an action based on some state in the resource's underlying model via the `resource` property on a resource or lens instance:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Nova\Http\Requests\ActionRequest;
+
+/**
+ * Get the actions available for the resource.
+ *
+ * @param  \Illuminate\Http\Request  $request
+ * @return array
+ */
+public function actions(Request $request)
+{
+    return [
+        (new Actions\CancelTrial)->canSee(function ($request) {
+            if ($request instanceof ActionRequest) {
+                return true;  
+            }
+
+            return $this->resource instanceof Model && $this->resource->isOnTrial();
+        }),
+    ];
+}
+```
+
+In Nova 4, `canRun` will be executed alongside `canSee` except when dealing with "Select All Matching". This allows users to focus `canSee` for User authorization for the action and `canRun` for model authorization for the action:
+
+```php
+/**
+ * Get the actions available for the resource.
+ *
+ * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+ * @return array
+ */
+public function actions(Request $request)
+{
+    return [
+        (new Actions\CancelTrial)->canRun(function ($request, $user) {
+            return $user->isOnTrial();
+        }),
+    ];
+}
+```
+
+You may want to skipped displaying the `CancelTrial` when "Select All Matching" is selected by adding the following:
+
+```php
+(new Actions\CancelTrial)->canSee(function ($request) {
+    return ! $request->allResourcesSelected();
+})->canRun(function ($request, $user) {
+    return $user->isOnTrial();
+}),
+```
+
 ### Changes to Authorization
 
 Nova 4 introduce following authorization breaking changes:


### PR DESCRIPTION
Blocked by https://github.com/laravel/nova/pull/1439

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>