### PR TITLE
Vue 3 changes for Nova 4

### DIFF
--- a/4.0/customization/cards.md
+++ b/4.0/customization/cards.md
@@ -129,7 +129,7 @@ When building routes for your card, you should **always** add authorization to t
 
 When Nova generates your card, `resources/js` and `resources/sass` directories are generated for you. These directories contain your card's JavaScript and Sass stylesheets. The primary files of interest in these directories are: `resources/js/components/Card.vue` and `resources/sass/card.scss`.
 
-The `Card.vue` file is a single-file Vue component that contains your card's front-end. From this file, you are free to build your card however you want. Your card can make HTTP requests using Axios via `Nova.request()`. In addition, the `lodash` library is globally available.
+The `Card.vue` file is a single-file Vue component that contains your card's front-end. From this file, you are free to build your card however you want. Your card can make HTTP requests using Axios via `Nova.request()`.
 
 #### Card Properties
 

--- a/4.0/customization/fields.md
+++ b/4.0/customization/fields.md
@@ -138,7 +138,7 @@ By default Custom field will be stub with `FormField` mixin. However you may wan
 
 ```js
 // before 
-import { FormField, HandlesValidationErrors } from 'laravel-nova'
+import { FormField, HandlesValidationErrors } from '@/mixins'
 
 export default {
   mixins: [FormField, HandlesValidationErrors],
@@ -147,7 +147,7 @@ export default {
 }
 
 // After
-import { DependentFormField, HandlesValidationErrors } from 'laravel-nova'
+import { DependentFormField, HandlesValidationErrors } from '@/mixins'
 
 export default {
   mixins: [DependentFormField, HandlesValidationErrors],

--- a/4.0/customization/fields.md
+++ b/4.0/customization/fields.md
@@ -103,7 +103,7 @@ Finally, Nova creates a `resources/js/components/FormField.vue` Vue component. T
 ```html
 <template>
     <default-field :field="field">
-        <template slot="field">
+        <template #field>
             <input :id="field.name" type="color"
                 class="w-full form-control form-input form-input-bordered"
                 :class="errorClasses"

--- a/4.0/customization/frontend.md
+++ b/4.0/customization/frontend.md
@@ -96,8 +96,7 @@ public function boot()
 Once the variable has been provided to Nova via the `provideToScript` method, you may access it on the global `Nova` JavaScript object:
 
 ```php
-const key = Nova.config.echo.key;
-const secret = Nova.config.echo.secret;
+const { key, secret } = Nova.config('echo');
 ```
 
 ### Localizations

--- a/4.0/customization/frontend.md
+++ b/4.0/customization/frontend.md
@@ -18,7 +18,7 @@ Nova.request().get('/nova-vendor/stripe-inspector/endpoint').then(response => {
 
 ### Event Bus
 
-The global `Nova` JavaScript object may be used as an event bus by your custom components. The bus provides the following methods, which correspond to and have the same behavior as the event methods [provided by Vue](https://vuejs.org/v2/api/#Instance-Methods-Events):
+The global `Nova` JavaScript object may be used as an event bus by your custom components. The bus provides the following methods, which correspond to and have the same behavior as the event methods [provided by tiny-emitter](https://www.npmjs.com/package/tiny-emitter):
 
 ```js
 Nova.$on(event, callback)
@@ -29,11 +29,11 @@ Nova.$emit(event, [...args])
 
 ### Notifications
 
-Nova's Vue configuration automatically registers the [Vue toasted plugin](https://github.com/shakee93/vue-toasted). So, within your custom components, you may leverage the `this.$toasted` object to display simple notifications:
+Nova configuration automatically registers the [toasted plugin](https://github.com/shakee93/toastedjs). So, within your custom components, you may leverage the `Nova.$toasted` object to display simple notifications:
 
 ```js
-this.$toasted.show('It worked!', { type: 'success' })
-this.$toasted.show('It failed!', { type: 'error' })
+Nova.$toasted.show('It worked!', { type: 'success' })
+Nova.$toasted.show('It failed!', { type: 'error' })
 ```
 
 ### Shortcuts

--- a/4.0/customization/frontend.md
+++ b/4.0/customization/frontend.md
@@ -68,8 +68,8 @@ Nova.disableShortcut(['ctrl+k', 'command+k'])
 The global `Nova` JavaScript object's `config` property contains the current Nova `base` path and `userId`:
 
 ```js
-const userId = Nova.config.userId;
-const basePath = Nova.config.base;
+const userId = Nova.config('userId');
+const basePath = Nova.config('base');
 ```
 
 However, you are free to add additional values to this object using the `Nova::provideToScript` method. You may call this method within a `Nova::serving` listener, which should typically be registered in the `boot` method of your application or custom component's service provider:

--- a/4.0/customization/frontend.md
+++ b/4.0/customization/frontend.md
@@ -29,11 +29,11 @@ Nova.$emit(event, [...args])
 
 ### Notifications
 
-Nova configuration automatically registers the [toasted plugin](https://github.com/shakee93/toastedjs). So, within your custom components, you may leverage the `Nova.$toasted` object to display simple notifications:
+You may display toast notification to users of your custom frontend components by calling the `success`, `error`, `info`, and `warning`, methods on the global `Nova` object:
 
 ```js
-Nova.$toasted.show('It worked!', { type: 'success' })
-Nova.$toasted.show('It failed!', { type: 'error' })
+Nova.success('It worked!')
+Nova.error('It failed!')
 ```
 
 ### Shortcuts
@@ -65,7 +65,7 @@ Nova.disableShortcut(['ctrl+k', 'command+k'])
 
 ### Global Variables
 
-The global `Nova` JavaScript object's `config` property contains the current Nova `base` path and `userId`:
+The global `Nova` JavaScript object's `config` method allows you to get the current Nova `base` path and `userId` configuration values:
 
 ```js
 const userId = Nova.config('userId');
@@ -93,7 +93,8 @@ public function boot()
 }
 ```
 
-Once the variable has been provided to Nova via the `provideToScript` method, you may access it on the global `Nova` JavaScript object:
+Once the variable has been provided to Nova via the `provideToScript` method, you may access it using the global `Nova` JavaScript object
+s `config` method:
 
 ```js
 const driver = Nova.config('mail_driver');

--- a/4.0/customization/frontend.md
+++ b/4.0/customization/frontend.md
@@ -6,19 +6,9 @@
 
 When building custom Nova tools, resource tools, cards, and fields, you may use a variety of helpers that are globally available to your JavaScript components.
 
-### Axios
-
-The [Axios HTTP library](https://github.com/axios/axios) is globally available, allowing you to easily make requests to your custom component's Laravel controllers:
-
-```js
-axios.get('/nova-vendor/stripe-inspector/endpoint').then(response => {
-    // ...
-})
-```
-
 #### Nova Requests
 
-As an alternative to using Axios directly, you may use the `Nova.request()` method. This method configures a separate instance of Axios that has pre-configured interceptors to handle and redirect on `401`, `403`, and `500` level server errors:
+You may use the `Nova.request()` method to make XHR request using `axios` API. This method configures a separate instance of Axios that has pre-configured interceptors to handle and redirect on `401`, `403`, and `500` level server errors:
 
 ```js
 Nova.request().get('/nova-vendor/stripe-inspector/endpoint').then(response => {

--- a/4.0/customization/frontend.md
+++ b/4.0/customization/frontend.md
@@ -118,7 +118,3 @@ php artisan nova:publish
 ```
 
 Please note, compiling Nova's assets for production purposes is not supported.
-
-### Other Available Libraries
-
-The [Lodash](https://lodash.com/) library are globally available to your custom components.

--- a/4.0/customization/resource-tools.md
+++ b/4.0/customization/resource-tools.md
@@ -155,7 +155,7 @@ When building routes for your tool, you should **always** add authorization to t
 
 When Nova generates your tool, `resources/js` and `resources/sass` directories are generated for you. These directories contain your tool's JavaScript and Sass stylesheets. The primary files of interest in these directories are: `resources/js/components/Tool.vue` and `resources/sass/tool.scss`.
 
-The `Tool.vue` file is a single-file Vue component that contains your tool's front-end. From this file, you are free to build your tool however you want. Your tool can make HTTP requests using Axios via `Nova.request()`. In addition, the `lodash` library is globally available.
+The `Tool.vue` file is a single-file Vue component that contains your tool's front-end. From this file, you are free to build your tool however you want. Your tool can make HTTP requests using Axios via `Nova.request()`.
 
 #### Resource Tool Properties
 

--- a/4.0/customization/tools.md
+++ b/4.0/customization/tools.md
@@ -147,7 +147,7 @@ Your component is bootstrapped and Inertia.js components are registered in the `
 
 ```js
 Nova.booting((Vue, store) => {
-  Vue.component('PriceTrackerLogo', require('./components/Logo').default)
+  Vue.component('PriceTrackerHeader', require('./components/Header').default)
 })
 ```
 
@@ -171,9 +171,14 @@ npm run watch
 
 #### Vue Page Components & Nova Plugins
 
-Vue page components contained by your tool have access to all of the plugins registered by Nova, including `vue-meta`, `portal-vue`, and `v-tooltip`. For example, your tool's `resources/js/components/Tool.vue` stub will contain a default page title which is managed by the `vue-meta` plugin:
+Vue page components contained by your tool have access to all of the components and plugins registered by Nova, including `v-tooltip`. For example, your tool's `resources/js/pages/Tool.vue` stub will contain a default page title which is managed by the Inertia.js `Head` component:
 
 ```js
+<template>
+  <div>
+    <Head title="PriceTracker" />
+  </div>
+</template>
 export default {
   metaInfo() {
     return {

--- a/4.0/customization/tools.md
+++ b/4.0/customization/tools.md
@@ -179,13 +179,6 @@ Vue page components contained by your tool have access to all of the components 
 </template>
 ```
 
-::: tip Available Layouts
-Nova provides 2 layouts; 
-
-- `AppLayout`
-- `Guest` 
-:::
-
 ### Sidebar Icons
 
 Nova utilizes the free icon set [Heroicons UI](https://github.com/sschoger/heroicons-ui) from designer [Steve Schoger](https://twitter.com/steveschoger). Feel free to use these icons to match the look and feel of Nova's built-in ones.

--- a/4.0/customization/tools.md
+++ b/4.0/customization/tools.md
@@ -179,16 +179,6 @@ Vue page components contained by your tool have access to all of the components 
 </template>
 ```
 
-#### Persistent Layout
-
-To use Inertia.js persistent layout on a page component, you can set the following value on each page:
-
-```js
-export default {
-  novaLayout: 'AppLayout'
-},
-```
-
 ::: tip Available Layouts
 Nova provides 2 layouts; 
 

--- a/4.0/customization/tools.md
+++ b/4.0/customization/tools.md
@@ -107,7 +107,7 @@ Nova utilizes the free icon set [Heroicons UI](https://github.com/sschoger/heroi
 
 When Nova generates your tool, `resources/js` and `resources/sass` directories are generated for you. These directories contain your tool's JavaScript and Sass stylesheets. The primary files of interest in these directories are: `resources/js/components/Tool.vue` and `resources/sass/tool.scss`.
 
-The `Tool.vue` file is a single-file Vue component that contains your tool's front-end. From this file, you are free to build your tool however you want. Your tool can make HTTP requests using Axios via `Nova.request()`. In addition, the `lodash` library is globally available.
+The `Tool.vue` file is a single-file Vue component that contains your tool's front-end. From this file, you are free to build your tool however you want. Your tool can make HTTP requests using Axios via `Nova.request()`.
 
 #### Registering Assets
 

--- a/4.0/customization/tools.md
+++ b/4.0/customization/tools.md
@@ -175,18 +175,26 @@ Vue page components contained by your tool have access to all of the components 
 
 ```js
 <template>
-  <div>
-    <Head title="PriceTracker" />
-  </div>
+  <Head title="PriceTracker" />
 </template>
-export default {
-  metaInfo() {
-    return {
-      title: 'PriceTracker',
-    }
-  }
-}
 ```
+
+#### Persistent Layout
+
+To use Inertia.js persistent layout on a page component, you can set the following value on each page:
+
+```js
+export default {
+  novaLayout: 'AppLayout'
+},
+```
+
+::: tip Available Layouts
+Nova provides 2 layouts; 
+
+- `AppLayout`
+- `Guest` 
+:::
 
 ### Sidebar Icons
 

--- a/4.0/upgrade.md
+++ b/4.0/upgrade.md
@@ -244,6 +244,30 @@ Nova::router()
     });
 ```
 
+### Removal of `laravel-nova` NPM Dependencies
+
+Nova 4 has merged `laravel-nova` codebase into `laravel/nova` repository and this would any Custom Fields and Tools depending on `laravel-nova` mixins. You need to manually copy all relevants files to `resources/js/mixins` and update `webpack.mix.js`:
+
+```js
+const mix = require('laravel-mix')
+cont path = require('path')
+
+mix.alias({
+  '@': path.join(__dirname, 'resources/js/'),
+})
+```
+
+To import the mixin you can do the following:
+
+```js
+// Before
+import { FormField, HandlesValidationErrors } from 'laravel-nova'
+
+// After
+import { FormField, HandlesValidationErrors } from '@/mixins'
+```
+
+
 ### Event Cancellation On Save
 
 Nova 3 ignores event cancellation when creating or updating a resource. For example, the following code will still persist the `User` resource to the database:

--- a/4.0/upgrade.md
+++ b/4.0/upgrade.md
@@ -203,6 +203,26 @@ Nova 4 utilizes native `<input type="date" />` and `<input type="datetime-local"
 
 ## Medium Impact Changes
 
+### Vue 3 Upgrades
+
+Nova 4 has been upgraded to use Vue 3, in order to upgrade all Custom Cards, Custom Fields, Custom Filters, Resource Tools and Tools to support Vue 3 please consider the following changes to `webpack.mix.js`:
+
+```js
+// Before
+mix.js('resources/js/field.js', 'js') 
+
+// After
+mix.js('resources/js/field.js', 'js').vue({ version: 3 })
+  .webpackConfig({
+    externals: {
+      vue: 'Vue',
+    },
+    output: {
+      uniqueName: 'vendor/package',
+    }
+  })
+```
+
 ### Replacing Vue Router With Inertia.js
 
 **This change primarily affects the installation of custom tools that utilize Vue routing.**
@@ -249,8 +269,8 @@ Nova::router()
 Nova 4 has merged `laravel-nova` codebase into `laravel/nova` repository and this would any Custom Fields and Tools depending on `laravel-nova` mixins. You need to manually copy all relevants files to `resources/js/mixins` and update `webpack.mix.js`:
 
 ```js
-const mix = require('laravel-mix')
-cont path = require('path')
+let mix = require('laravel-mix')
+let path = require('path')
 
 mix.alias({
   '@': path.join(__dirname, 'resources/js/'),
@@ -266,7 +286,6 @@ import { FormField, HandlesValidationErrors } from 'laravel-nova'
 // After
 import { FormField, HandlesValidationErrors } from '@/mixins'
 ```
-
 
 ### Event Cancellation On Save
 


### PR DESCRIPTION
Related changes:

* [x] removal of `lodash` from globally available library
* [x] removal of `laravel-nova` npm dependencies
* [x] configuring `webpackConfig.externals.vue` for plugins compilation.
* [x] Changes from `Nova.config.key` to `Nova.config(key)`
