### PR TITLE
Add `UiAvatar` field

### DIFF
--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -1182,21 +1182,23 @@ $schedule->call(new PruneStaleAttachments)->daily();
 
 ### Ui-Avatar Field
 
-The `UiAvatar` field does not correspond to any column in your application's database. Instead, it will display the name initial image of the model it is associated with.
+The `UiAvatar` field does not correspond to any column in your application's database. Instead, this field will generate a simple avatar containing the user's initials. This field is powered by [ui-avatars.com](https://ui-avatars.com).
 
-By default, the `UiAvatar` URL will be generated based on the value of the model's `name` column. However, if your user's name are not stored in the `name` column, you may pass a custom column name to the field's `make` method:
+@SCREENSHOT
+
+By default, the `UiAvatar` image will be generated based on the value of the model's `name` column. However, if your user's names are not stored in the `name` column, you may pass a custom column name to the field's `make` method:
 
 ```php
 use Laravel\Nova\Fields\UiAvatar;
 
-// Using the "email" column...
+// Using the "name" column...
 UiAvatar::make(),
 
-// Using the "fullname" column...
-UiAvatar::make('Avatar', 'fullname'),
+// Using a custom column...
+UiAvatar::make('Avatar', 'full_name'),
 ```
 
-You may also use custom resolve value to generate name, for example if you want to use the first character of model's email address and the first character from the email address domain name:
+If necessary, you may invoke the `resolveUsing` method to specify a closure that should be invoked to determine the name that should be used to generate the avatar:
 
 ```php
 UiAvatar::make()->resolveUsing(function () {
@@ -1210,14 +1212,14 @@ You may use the `squared` method to display the image's thumbnail with squared e
 UiAvatar::make('Avatar', 'fullname')->squared(),
 ```
 
-Additional options available from [ui-avatars.com](https://ui-avatars.com)'s settings:
+Additional options available when defining `UiAvatar` fields include:
 
 | Option | Method | Description
 |:-------|:-------|:------
-| Font Size | `fontSize(0.4)` | Set font size between `0.1` to `1`.
-| Bold | `bold()` | Set font weight to bold
-| Background Color | `backgroundColor('1D4ED7')` | Set hex color for the image background
-| Font Color | `color('FFFFFF')` | Set hex color for the image font
+| Font Size | `fontSize(0.4)` | Set a font size between `0.1` to `1`.
+| Bold | `bold()` | Set font weight to bold.
+| Background Color | `backgroundColor('1D4ED7')` | Set the hex color for the image background.
+| Text Color | `color('FFFFFF')` | Set the hex color for the image text.
 
 ### URL Field
 

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -284,6 +284,7 @@ Nova ships with a variety of field types. So, let's explore all of the available
 - [Textarea](#textarea-field)
 - [Timezone](#timezone-field)
 - [Trix](#trix-field)
+- [UI-Avatar](#ui-avatar-field)
 - [URL](#url-field)
 - [Vapor File](#vapor-file-field)
 - [Vapor Image](#vapor-image-field)
@@ -1178,6 +1179,45 @@ use Laravel\Nova\Trix\PruneStaleAttachments;
 
 $schedule->call(new PruneStaleAttachments)->daily();
 ```
+
+### Ui-Avatar Field
+
+The `UiAvatar` field does not correspond to any column in your application's database. Instead, it will display the name initial image of the model it is associated with.
+
+By default, the `UiAvatar` URL will be generated based on the value of the model's `name` column. However, if your user's name are not stored in the `name` column, you may pass a custom column name to the field's `make` method:
+
+```php
+use Laravel\Nova\Fields\UiAvatar;
+
+// Using the "email" column...
+UiAvatar::make(),
+
+// Using the "fullname" column...
+UiAvatar::make('Avatar', 'fullname'),
+```
+
+You may also use custom resolve value to generate name, for example if you want to use the first character of model's email address and the first character from the email address domain name:
+
+```php
+UiAvatar::make()->resolveUsing(function () {
+    return implode(' ', explode('@', $this->email));
+}),
+```
+
+You may use the `squared` method to display the image's thumbnail with squared edges. Additionally, you may use the `rounded` method to display the images with fully-rounded edges:
+
+```php
+UiAvatar::make('Avatar', 'fullname')->squared(),
+```
+
+Additional options available from [ui-avatars.com](https://ui-avatars.com)'s settings:
+
+| Option | Method | Description
+|:-------|:-------|:------
+| Font Size | `fontSize(0.4)` | Set font size between `0.1` to `1`.
+| Bold | `bold()` | Set font weight to bold
+| Background Color | `backgroundColor('1D4ED7')` | Set hex color for the image background
+| Font Color | `color('FFFFFF')` | Set hex color for the image font
 
 ### URL Field
 

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -1180,7 +1180,7 @@ use Laravel\Nova\Trix\PruneStaleAttachments;
 $schedule->call(new PruneStaleAttachments)->daily();
 ```
 
-### Ui-Avatar Field
+### UI-Avatar Field
 
 The `UiAvatar` field does not correspond to any column in your application's database. Instead, this field will generate a simple avatar containing the user's initials. This field is powered by [ui-avatars.com](https://ui-avatars.com).
 


### PR DESCRIPTION
Code PR: https://github.com/laravel/nova/pull/1683

Not sure how we want to introduce the `Avatar` alias for Gravatar and UiAvatar field.

```php
use Laravel\Nova\Fields\Avatar;


// Use Gravatar
Avatar::gravatar(),

// Use UI-Avatars
Avatar::uiavatar(),
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>