### PR TITLE
Update Nova 3 details

### DIFF
--- a/3.0/installation.md
+++ b/3.0/installation.md
@@ -7,7 +7,7 @@
 Laravel Nova has a few requirements you should be aware of before installing:
 
 - Composer
-- Laravel Framework 7.0+
+- Laravel Framework 8.0+
 - Laravel Mix
 - Node.js (Version 14)
 - NPM

--- a/3.0/metrics/defining-metrics.md
+++ b/3.0/metrics/defining-metrics.md
@@ -387,7 +387,7 @@ return $this->countByDays($request, User::class)
             ->showLatestValue();
 ```
 
-You may customize the display format using the `format` method. The format must be a format supported by [Numeral.js](http://numeraljs.com/#format):
+You may customize the display format using the `format` method. The format must be a format supported by [Numbro](http://numbrojs.com/old-format.html):
 
 ```php
 return $this->countByDays($request, User::class)


### PR DESCRIPTION
* Minimum Laravel Framework is now version 8 
* Uses Numbro instead of Numeral (Nova 4 docs has been updated)

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>