### PR TITLE
Removed the word 'of' for consistancy

### DIFF
--- a/4.0/installation.md
+++ b/4.0/installation.md
@@ -165,7 +165,7 @@ Nova uses the default authentication guard defined in your `auth` configuration 
 
 ### Customizing Nova's Password Reset Functionality
 
-Nova uses the default password reset broker defined in your `auth` configuration file. If you would like to customize this broker, you may set the `passwords` value within of Nova's configuration file:
+Nova uses the default password reset broker defined in your `auth` configuration file. If you would like to customize this broker, you may set the `passwords` value within Nova's configuration file:
 
 ```php
 'passwords' => env('NOVA_PASSWORDS', null),


### PR DESCRIPTION
I propose to remove the word 'of' for consistency in the documentation.

It also seems to be the incorrect use of prepositions according to Grammarly.