### PR TITLE
Change `Nova::userMenu()` example to avoid confusion

### DIFF
--- a/4.0/customization/menus.md
+++ b/4.0/customization/menus.md
@@ -88,10 +88,10 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     public function boot()
     {
         Nova::userMenu(function (Request $request, Menu $menu) {
-            if ($request->user()->isImpersonating()) {
+            if ($request->user()->subscribed()) {
                 $menu->append(
-                    MenuItem::make('Stop Impersonating')
-                        ->path('/impersonate/stop')
+                    MenuItem::make('Subscriber Dashboard')
+                        ->path('/subscribers/dashboard')
                 );
             }
 


### PR DESCRIPTION
Closes laravel/nova-issues#3840

The example creates confusion and seems to indicate that stopping impersonate users requires manual menu registration.

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>