### PR TITLE
Use the correct method name for dashboard name change

### DIFF
--- a/4.0/customization/dashboards.md
+++ b/4.0/customization/dashboards.md
@@ -66,7 +66,7 @@ class UserInsights extends Dashboard
 
 #### Dashboard Names
 
-By default, Nova will use the dashboard's class name to determine the displayable name of your dashboard that should be placed in the left-side navigation bar. You may customize the name of the dashboard displayed in the left-side navigation bar by overriding the `name` method within your dashboard class:
+By default, Nova will use the dashboard's class name to determine the displayable name of your dashboard that should be placed in the left-side navigation bar. You may customize the name of the dashboard displayed in the left-side navigation bar by overriding the `label` method within your dashboard class:
 
 ```php
 /**
@@ -74,7 +74,7 @@ By default, Nova will use the dashboard's class name to determine the displayabl
  *
  * @return string
  */
-public function name()
+public function label()
 {
     return 'User Insights';
 }


### PR DESCRIPTION
There is no `name` method in the parent class, the `label` method needs to be overridden to achieve the stated result of changing the dashboard name in the left menu.