### PR TITLE
Change way class is called to avoid static analysis error

### DIFF
--- a/4.0/customization/menus.md
+++ b/4.0/customization/menus.md
@@ -46,7 +46,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
     
         Nova::mainMenu(function (Request $request) {
             return [
-                MenuSection::dashboard(Main::class)->icon('chart-bar'),
+                MenuSection::dashboard(new Main)->icon('chart-bar'),
 
                 MenuSection::make('Customers', [
                     MenuItem::resource(User::class),


### PR DESCRIPTION
With `MenuSection::dashboard(Main::class)`, static analysis tools return the following error: 

```
Parameter #1 $dashboard of static method Laravel\Nova\Menu\MenuSection::dashboard() expects Laravel\Nova\Dashboard, string given. 
```