### PR TITLE
Use `resource_path()` to fetch Nova's logo

### DIFF
--- a/4.0/installation.md
+++ b/4.0/installation.md
@@ -158,7 +158,7 @@ To customize the logo used at the top left of the Nova interface, you may specif
 
 ```php
 'brand' => [
-    'logo' => realpath(__DIR__.'/../public/img/example-logo.svg'),
+    'logo' => resource_path('/img/example-logo.svg'),
 
     // ...
 ],


### PR DESCRIPTION
insteads of using relative path to public, it might be best to use
`resource_path()` as it also supported on Laravel Vapor: https://github.com/laravel/nova-issues/discussions/4041#discussioncomment-2607710

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>