### PR TITLE
Fixes `Resource::menu()` usage example and link to menus.

### DIFF
--- a/4.0/resources/README.md
+++ b/4.0/resources/README.md
@@ -97,14 +97,13 @@ You can customize the resource's menu by defining a `menu` method on your resour
 
 ```php
 use Illuminate\Http\Request;
-use Laravel\Nova\Menu\MenuItem;
 
 /**
  * Get the menu that should represent the resource.
  *
  * @return \Laravel\Nova\Menu\MenuItem
  */
-public static function menu(Request $request)
+public function menu(Request $request)
 {
     return parent::menu($request)->withBadge(function () {
         return static::$model::count();
@@ -112,7 +111,7 @@ public static function menu(Request $request)
 }
 ```
 
-Please refer to the documentation on [menu customization](./menus) for more information.
+Please refer to the documentation on [menu customization](./../customization/menus.html) for more information.
 
 ## Grouping Resources
 


### PR DESCRIPTION
fixes laravel/nova-issues#4468

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>