### PR TITLE
Add documentation about Badge labels

### DIFF
--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -376,6 +376,16 @@ Badge::make('Status')->map([
 ]),
 ```
 
+If you'd like to customize the label that is displayed you can use the `label` method:
+
+```php
+Badge::make('Status')->map([
+    'draft' => 'danger',
+    'published' => 'success',
+])->label(function ($value) {
+    return __($value);
+}),
+```
 
 ### Boolean Field
 


### PR DESCRIPTION
There is not mention of the `Badge` field's `label` method. This PR adds that.