### PR TITLE
Add note about `step('any')` on Number fields

### DIFF
--- a/3.0/resources/fields.md
+++ b/3.0/resources/fields.md
@@ -792,6 +792,8 @@ You may use the `min`, `max`, and `step` methods to set their corresponding attr
 Number::make('price')->min(1)->max(1000)->step(0.01),
 ```
 
+To allow arbitrary-precision decimal values, set `step('any')` on the field.
+
 ### Password Field
 
 The `Password` field provides an `input` control with a `type` attribute of `password`:

--- a/3.0/resources/fields.md
+++ b/3.0/resources/fields.md
@@ -792,7 +792,11 @@ You may use the `min`, `max`, and `step` methods to set their corresponding attr
 Number::make('price')->min(1)->max(1000)->step(0.01),
 ```
 
-To allow arbitrary-precision decimal values, set `step('any')` on the field.
+You may also allow arbitrary-precision decimal values:
+
+```php
+Number::make('price')->min(1)->max(1000)->step('any'),
+```
 
 ### Password Field
 

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -858,7 +858,11 @@ You may use the `min`, `max`, and `step` methods to set the corresponding HTML a
 Number::make('price')->min(1)->max(1000)->step(0.01),
 ```
 
-To allow arbitrary-precision decimal values, set `step('any')` on the field.
+You may also allow arbitrary-precision decimal values:
+
+```php
+Number::make('price')->min(1)->max(1000)->step('any'),
+```
 
 ### Password Field
 

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -858,6 +858,8 @@ You may use the `min`, `max`, and `step` methods to set the corresponding HTML a
 Number::make('price')->min(1)->max(1000)->step(0.01),
 ```
 
+To allow arbitrary-precision decimal values, set `step('any')` on the field.
+
 ### Password Field
 
 The `Password` field provides an `input` control with a `type` attribute of `password`:


### PR DESCRIPTION
I ran into trouble with `Number` fields because by default they don't accept floating point values, only integers. For example `Number::make('latitude')` is unlikely to be usable. The obvious thing to do is to add a step size, however, that incurs some annoying behaviour too because the step size not only determines the increment size that the arrow buttons on the widget use, but also a strict precision for validation. For example for a field declared like this:

    Number::make('latitude')
        ->step(0.01)

an input value of `0.001` will fail validation. Setting the step size to something very small gets around the validation issue, but then makes the up and down buttons mostly useless.

It turns out that there is an alternative value for the step input which is [`any`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#step). This results in the up and down buttons using integer values, and floating point values have no precision limits, which is just what I was looking for.

This option isn't obvious, so this PR adds a note about it for Nova 3 and 4 docs.