### PR TITLE
Update validation.md

### DIFF
--- a/3.0/resources/validation.md
+++ b/3.0/resources/validation.md
@@ -84,7 +84,7 @@ The `afterValidation` method will always be called after a resource has been val
  */
 protected static function afterValidation(NovaRequest $request, $validator)
 {
-    if ($this->somethingElseIsInvalid()) {
+    if (self::somethingElseIsInvalid()) {
         $validator->errors()->add('field', 'Something is wrong with this field!');
     }
 }
@@ -104,7 +104,7 @@ The `afterCreationValidation` method will be called after a resource that is bei
  */
 protected static function afterCreationValidation(NovaRequest $request, $validator)
 {
-    if ($this->somethingElseIsInvalid()) {
+    if (self::somethingElseIsInvalid()) {
         $validator->errors()->add('field', 'Something is wrong with this field!');
     }
 }
@@ -124,7 +124,7 @@ The `afterUpdateValidation` method will be called after a resource that is being
  */
 protected static function afterUpdateValidation(NovaRequest $request, $validator)
 {
-    if ($this->somethingElseIsInvalid()) {
+    if (self::somethingElseIsInvalid()) {
         $validator->errors()->add('field', 'Something is wrong with this field!');
     }
 }


### PR DESCRIPTION
The code examples provided for the `afterValidation`, `afterCreationValidation` and `afterUpdateValidation` give the error of
```
Using '$this' when not in object context
```

This is due to the use of `$this` in the static function.