### PR TITLE
`4.13.0` release changes

### DIFF
--- a/4.0/customization/menus.md
+++ b/4.0/customization/menus.md
@@ -367,7 +367,7 @@ use Laravel\Nova\Menu\MenuItem;
 MenuItem::externalLink('Documentation', 'https://nova.laravel.com/docs')
 ```
 
-You may set the link to redirects the user to a location using a separate tab, you may use the `openOnNewTab` method:
+To specify the external link should open using a separate tab, you may call the `openOnNewTab` helper on your menu item:
 
 ```php
 MenuItem::externalLink('Documentation', 'https://nova.laravel.com/docs')->openOnNewTab();

--- a/4.0/customization/menus.md
+++ b/4.0/customization/menus.md
@@ -367,7 +367,7 @@ use Laravel\Nova\Menu\MenuItem;
 MenuItem::externalLink('Documentation', 'https://nova.laravel.com/docs')
 ```
 
-To specify the external link should open using a separate tab, you may call the `openOnNewTab` helper on your menu item:
+To specify an external link should open within a separate tab, you may call the `openOnNewTab` method on your menu item:
 
 ```php
 MenuItem::externalLink('Documentation', 'https://nova.laravel.com/docs')->openOnNewTab();

--- a/4.0/customization/menus.md
+++ b/4.0/customization/menus.md
@@ -367,6 +367,12 @@ use Laravel\Nova\Menu\MenuItem;
 MenuItem::externalLink('Documentation', 'https://nova.laravel.com/docs')
 ```
 
+You may set the link to redirects the user to a location using a separate tab, you may use the `openOnNewTab` method:
+
+```php
+MenuItem::externalLink('Documentation', 'https://nova.laravel.com/docs')->openOnNewTab();
+```
+
 You may also call the `method` helper to pass in the HTTP method, request data, and any HTTP headers that should be sent to your application when the link is clicked. This is typically useful for items like logout links, which should be `POST` requests:
 
 ```php

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -813,7 +813,7 @@ By default, Markdown fields will not display their content when viewing a resour
 Markdown::make('Biography')->alwaysShow(),
 ```
 
-The Markdown field uses the `league/commonmark` package to parse Markdown content. By default, it uses a parsing strategy similar to GitHub Flavoured Markdown, which does not allow certain HTML within the Markdown content. However, you can change the parsing strategy using the `preset` method. The currently supported presets are `default`, `commonmark`, and `zero`:
+The Markdown field uses the `league/commonmark` package to parse Markdown content. By default, it uses a parsing strategy similar to GitHub Flavoured Markdown, which does not allow certain HTML within the Markdown content. However, you can change the parsing strategy using the `preset` method. The currently built-in presets are `default`, `commonmark`, and `zero`:
 
 ```php
 Markdown::make('Biography')->preset('commonmark'),

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -819,6 +819,29 @@ The Markdown field uses the `league/commonmark` package to parse Markdown conten
 Markdown::make('Biography')->preset('commonmark'),
 ```
 
+Using the `preset()` method, you can also register and use custom preset implementation such as:
+
+```php
+use Illuminate\Support\Str;
+use Laravel\Nova\Fields\Markdown;
+use Laravel\Nova\Fields\Markdown\MarkdownPreset;
+
+Markdown::make('Biography')->preset('github', new class implements MarkdownPreset {
+    /**
+     * Convert the given content from markdown to HTML.
+     *
+     * @param  string  $content
+     * @return string
+     */
+    public function convert(string $content)
+    {
+        return Str::of('# Taylor <b>Otwell</b>')->markdown([
+            'html_input' => 'strip',
+        ]);
+    }
+}),
+```
+
 ### MultiSelect Field
 
 The `MultiSelect` field provides a `Select` field that allows multiple selection options. This field pairs nicely with model attributes that are cast to `array` or equivalent:

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -835,7 +835,7 @@ Markdown::make('Biography')->preset('github', new class implements MarkdownPrese
      */
     public function convert(string $content)
     {
-        return Str::of('# Taylor <b>Otwell</b>')->markdown([
+        return Str::of($content)->markdown([
             'html_input' => 'strip',
         ]);
     }

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -819,7 +819,7 @@ The Markdown field uses the `league/commonmark` package to parse Markdown conten
 Markdown::make('Biography')->preset('commonmark'),
 ```
 
-Using the `preset` method, you can also register and use custom preset implementation such as:
+Using the `preset` method, you may register and use custom preset implementations:
 
 ```php
 use Illuminate\Support\Str;

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -813,7 +813,7 @@ By default, Markdown fields will not display their content when viewing a resour
 Markdown::make('Biography')->alwaysShow(),
 ```
 
-The Markdown field uses the `markdown-it` npm package to parse Markdown content. By default, it uses a parsing strategy similar to GitHub Flavoured Markdown, which does not allow HTML within the Markdown content. However, you can change the parsing strategy using the `preset` method. The currently supported presets are `default`, `commonmark`, and `zero`:
+The Markdown field uses the `league/commonmark` package to parse Markdown content. By default, it uses a parsing strategy similar to GitHub Flavoured Markdown, which does not allow certain HTML within the Markdown content. However, you can change the parsing strategy using the `preset` method. The currently supported presets are `default`, `commonmark`, and `zero`:
 
 ```php
 Markdown::make('Biography')->preset('commonmark'),

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -813,13 +813,13 @@ By default, Markdown fields will not display their content when viewing a resour
 Markdown::make('Biography')->alwaysShow(),
 ```
 
-The Markdown field uses the `league/commonmark` package to parse Markdown content. By default, it uses a parsing strategy similar to GitHub Flavoured Markdown, which does not allow certain HTML within the Markdown content. However, you can change the parsing strategy using the `preset` method. The currently built-in presets are `default`, `commonmark`, and `zero`:
+The Markdown field uses the `league/commonmark` package to parse Markdown content. By default, it uses a parsing strategy similar to GitHub Flavoured Markdown, which does not allow certain HTML within the Markdown content. However, you can change the parsing strategy using the `preset` method. Currently, the following built-in presets are `default`, `commonmark`, and `zero`:
 
 ```php
 Markdown::make('Biography')->preset('commonmark'),
 ```
 
-Using the `preset()` method, you can also register and use custom preset implementation such as:
+Using the `preset` method, you can also register and use custom preset implementation such as:
 
 ```php
 use Illuminate\Support\Str;


### PR DESCRIPTION
* `MenuItem` defaults to open on current tab and you can use `openOnNewTab()` method to target to new tab.
* `Markdown` field parsing changed from `markdown-it` npm package to `league/commonmark`.