### PR TITLE
Install NPM using `npm ci` insteads of `npm install`

### DIFF
--- a/4.0/customization/frontend.md
+++ b/4.0/customization/frontend.md
@@ -137,7 +137,7 @@ By default, Nova's JavaScript is compiled for production. As such, you will not 
 ```bash
 cd ./vendor/laravel/nova
 mv webpack.mix.js.dist webpack.mix.js
-npm install
+npm ci
 npm run dev
 rm -rf node_modules
 cd -


### PR DESCRIPTION
`npm ci` ensure the dependencies installed are locked based on `package-lock.json`