### PR TITLE
fix: version 4 upgrade doc typo

### DIFF
--- a/4.0/upgrade.md
+++ b/4.0/upgrade.md
@@ -196,7 +196,7 @@ protected function dashboards()
 
 ### Dashboard Methods
 
-In Nova 4, the `cards` and `uriKey` methods defined on dashboard classes are no longer static. You should update your methods accordingly:
+In Nova 4, the `label` and `uriKey` methods defined on dashboard classes are no longer static. You should update your methods accordingly:
 
 ```php
 /**


### PR DESCRIPTION
There was a typo in the Nova 4 upgrade guide. 

I've fixed that in this PR. 