### PR TITLE
Update fields.md

### DIFF
--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -170,9 +170,10 @@ The available methods that may be defined for individual display contexts are:
 - `fieldsForInlineCreate`
 - `fieldsForCreate`
 - `fieldsForUpdate`
+- `fieldsForPreview`
 
 :::tip Dynamic Field Methods Precedence ::
-The `fieldsForIndex`, `fieldsForDetail`, `fieldsForInlineCreate`, `fieldsForCreate`, and `fieldsForUpdate` methods always take precedence over the `fields` method.
+The `fieldsForIndex`, `fieldsForDetail`, `fieldsForInlineCreate`, `fieldsForCreate`,`fieldsForUpdate` and `fieldsForPreview` methods always take precedence over the `fields` method.
 :::
 
 ## Default Values

--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -173,7 +173,7 @@ The available methods that may be defined for individual display contexts are:
 - `fieldsForPreview`
 
 :::tip Dynamic Field Methods Precedence ::
-The `fieldsForIndex`, `fieldsForDetail`, `fieldsForInlineCreate`, `fieldsForCreate`,`fieldsForUpdate` and `fieldsForPreview` methods always take precedence over the `fields` method.
+The `fieldsForIndex`, `fieldsForDetail`, `fieldsForInlineCreate`, `fieldsForCreate`,`fieldsForUpdate`, and `fieldsForPreview` methods always take precedence over the `fields` method.
 :::
 
 ## Default Values


### PR DESCRIPTION
I was searching for a way to define "fieldsForIndex" seperately. Turns out it already exists, but was not yet documented.
This commit adds undocumented "fieldsForIndex" to the docs pages for fields for other users.