### PR TITLE
`Nova::userTimezone()` can be used with Tool routes without `Authenticate` middleware

### DIFF
--- a/4.0/resources/date-fields.md
+++ b/4.0/resources/date-fields.md
@@ -68,7 +68,7 @@ public function boot()
     parent::boot();
 
     Nova::userTimezone(function (Request $request) {
-        return $request->user()->timezone;
+        return $request->user()?->timezone;
     });
 }
 ```


### PR DESCRIPTION
In general `userTimezone()` share data is available from all Inertia requests and it can be used in page without `Authenticate` middleware.