### PR TITLE
Use `FormData::boolean()` to handle Boolean field

### DIFF
--- a/4.0/resources/fields.md
+++ b/4.0/resources/fields.md
@@ -1842,7 +1842,7 @@ BelongsTo::make('User')
     ->hide()
     ->rules('sometimes')
     ->dependsOn('anonymous', function (BelongsTo $field, NovaRequest $request, FormData $formData) {
-        if ($formData->anonymous === false) {
+        if ($formData->boolean('anonymous') === false) {
             $field->show()->rules('required');
         }
     }),


### PR DESCRIPTION
The request send the value as `string` and not `boolean`. We should suggest using `boolean()` helper method in this case.

fixes laravel/nova-issues#5268

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>