### PR TITLE
Update documentation for dynamic data handling in result method

### DIFF
--- a/4.0/metrics/defining-metrics.md
+++ b/4.0/metrics/defining-metrics.md
@@ -212,6 +212,11 @@ If you are not able to use the included query helpers for building your value me
 ```php
 return $this->result(100)->previous(50);
 ```
+However, you are not restricted to static values. The result method can also handle dynamic data, such as filters that come through a request. Here's an example showing how you might apply a filter to a model using the applyFilterQuery method:
+
+```php
+return $this->result($this->applyFilterQuery($request, Model::class));
+```
 
 ## Trend Metrics
 

--- a/4.0/metrics/defining-metrics.md
+++ b/4.0/metrics/defining-metrics.md
@@ -215,7 +215,7 @@ return $this->result(100)->previous(50);
 However, you are not restricted to static values. The result method can also handle dynamic data, such as filters that come through a request. Here's an example showing how you might apply a filter to a model using the applyFilterQuery method:
 
 ```php
-return $this->result($this->applyFilterQuery($request, Model::class));
+return $this->result($this->applyFilterQuery($request, Model::class)->count());
 ```
 
 ## Trend Metrics

--- a/4.0/metrics/defining-metrics.md
+++ b/4.0/metrics/defining-metrics.md
@@ -212,7 +212,7 @@ If you are not able to use the included query helpers for building your value me
 ```php
 return $this->result(100)->previous(50);
 ```
-However, you are not restricted to static values. The result method can also handle dynamic data, such as filters that come through a request. Here's an example showing how you might apply a filter to a model using the applyFilterQuery method:
+The result method in Resource Index metrics can handle dynamic data, including filters received through a request. For instance, you can use the applyFilterQuery method to apply the selected filters on the resource to a model. Here's an example that illustrates this process:
 
 ```php
 return $this->result($this->applyFilterQuery($request, Model::class)->count());


### PR DESCRIPTION
This commit enhances the documentation for the 'result' method in the Value Metric section. It includes a new example demonstrating how to handle dynamic data, such as request filters, in the 'result' method. This change aims to provide a broader understanding of the flexibility and utility of the 'result' method. This wasn't documented and I figured it out by looking at the source code. Maybe it helps someone or maybe it should be discarded. Your call! :)