### PR TITLE
Update src/resources/index.md: replaced AppServiceProvider by EventServiceProvider

### DIFF
--- a/src/resources/index.md
+++ b/src/resources/index.md
@@ -265,7 +265,7 @@ use App\Models\User;
 use App\Observers\UserObserver;
 use Illuminate\Support\ServiceProvider;
 
-class AppServiceProvider extends ServiceProvider
+class EventServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap any application services.


### PR DESCRIPTION
The [laravel docs](https://laravel.com/docs/10.x/eloquent#defining-observers) state:

> To register an observer, you need to call the `observe` method on the model you wish to observe. You may register observers in the `boot` method of your application's `App\Providers\EventServiceProvider` service provider:

But the sample code, in the [Nova docs](https://nova.laravel.com/docs/4.0/resources/#resource-events) use the `AppServiceProvider`