### PR TITLE
Fix typo on resource tools page

### DIFF
--- a/src/customization/resource-tools.md
+++ b/src/customization/resource-tools.md
@@ -137,7 +137,7 @@ public function fields(NovaRequest $request)
     return [
         ID::make('ID', 'id')->sortable(),
 
-        StripInspector::make()->issuesRefunds(),
+        StripeInspector::make()->issuesRefunds(),
     ];
 }
 ```


### PR DESCRIPTION
Fixes typo on resource tools page (`StripInspector` to `StripeInspector`).