### PR TITLE
Fixes table formatting on Registering Actions page

### DIFF
--- a/src/actions/registering-actions.md
+++ b/src/actions/registering-actions.md
@@ -67,8 +67,8 @@ You may also use a variety of request methods to get the currently selected reso
 | Method                 | Return Type              | Description
 |:-----------------------|:-------------------------|:----------------------
 | `allResourcesSelected` | `bool`                   | Returns `true` if "Select all" selected. 
-| `selectedResourceIds`  | `\Illuminate\Support\Collection|null` | Returns `null` if "Select all" selected or returns a collection of selected resource IDs.
-| `selectedResources`    | `\Illuminate\Support\Collection|null` | Returns `null` if "Select all" selected or returns a collection of resource models.
+| `selectedResourceIds`  | `\Illuminate\Support\Collection\|null` | Returns `null` if "Select all" selected or returns a collection of selected resource IDs.
+| `selectedResources`    | `\Illuminate\Support\Collection\|null` | Returns `null` if "Select all" selected or returns a collection of resource models.
 
 ### Resource Specific Authorization
 


### PR DESCRIPTION
Fixes table formatting by escaping the vertical bar in code sections inside of the table in the [Authorization](https://nova.laravel.com/docs/actions/registering-actions.html#authorization) section of the Registering Actions page. 

Changes:
```
`\Illuminate\Support\Collection|null`
```
To:
```
`\Illuminate\Support\Collection\|null`
```
You can see the error visible in the second and third rows in the image below:
![image](https://github.com/laravel/nova-docs/assets/13026511/370954f8-b1b5-4d6d-954e-08b2d35267db)

I don't know how the docs page is created on the Nova site or if this change will show up correctly (because the ` is visible in the Nova docs), but the preview in GitHub shows that it is fixed.