### PR TITLE
Quote env var args in CI command

### DIFF
--- a/src/installation.md
+++ b/src/installation.md
@@ -126,7 +126,7 @@ It's not recommended to store your Composer `auth.json` file inside your project
 To authenticate Nova in these situations, you can use Composer's `config` command to set the configuration option inside your CI system's pipeline, injecting environment variables containing your Nova username and license key:
 
 ```bash
-composer config http-basic.nova.laravel.com ${NOVA_USERNAME} ${NOVA_LICENSE_KEY}
+composer config http-basic.nova.laravel.com "${NOVA_USERNAME}" "${NOVA_LICENSE_KEY}"
 ```
 
 ## Using Nova on Development & Staging Domains


### PR DESCRIPTION
In the docs section called [Authenticating Nova In CI Environments​](https://nova.laravel.com/docs/installation.html#authenticating-nova-in-ci-environments), there is a command to pass credentials through env vars to composer:

    composer config http-basic.nova.laravel.com ${NOVA_USERNAME} ${NOVA_LICENSE_KEY}

I ran into a problem with this a year ago, and it looked like it was a composer problem, for which I found [a workaround](https://github.com/composer/composer/discussions/11238). However, it turns out that the workaround was not the right approach. If the env vars are not set (for one reason or another), the command end up missing those arguments altogether, which changes it into a nonsensical composer command (asking for the config instead of setting it):

    composer config http-basic.nova.laravel.com

This PR avoids that problem by quoting the env vars in the command:

    composer config http-basic.nova.laravel.com "${NOVA_USERNAME}" "${NOVA_LICENSE_KEY}"

This way, if the vars are not set, it will end up as:

    composer config http-basic.nova.laravel.com "" ""

which will be correctly reported as incorrect credentials.