### PR TITLE
Added: line about brand logo having to be an SVG and not anything else

### DIFF
--- a/src/installation.md
+++ b/src/installation.md
@@ -184,6 +184,7 @@ To customize the logo used at the top left of the Nova interface, you may specif
 
 ```php
 'brand' => [
+    // must be an SVG and not a binary image file (png, jpg, etc.) in order to work
     'logo' => resource_path('/img/example-logo.svg'),
 
     // ...


### PR DESCRIPTION
If you use a brand image that is not an SVG, you will get an error in the Nova layout.

![image](https://github.com/laravel/nova-docs/assets/1425304/cd0cea75-24a3-4a95-a555-1896f76ab6d6)

Just added a single line comment in the example to indicate that it must be an SVG image for the logo.