### PR TITLE
Fix Heroicons website url

### DIFF
--- a/src/metrics/defining-metrics.md
+++ b/src/metrics/defining-metrics.md
@@ -831,7 +831,7 @@ MetricTableRow::make()
 
 :::tip Heroicons
 
-Nova utilizes the free icon set [Heroicons UI](https://github.com/sschoger/heroicons-ui) from designer [Steve Schoger](https://twitter.com/steveschoger). Feel free to use these icons to match the look and feel of Nova's built-in icons.
+Nova utilizes the free icon set [Heroicons UI](https://v1.heroicons.com/) from designer [Steve Schoger](https://twitter.com/steveschoger). Feel free to use these icons to match the look and feel of Nova's built-in icons.
 :::
 
 ### Customizing Table Metric Empty Text


### PR DESCRIPTION
Current url opens a Github repository, without any reference to icons website. Updated with url from Menu section of this docs