### PR TITLE
Fix installation link

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -82,7 +82,7 @@ export default defineConfigWithTheme<ThemeConfig>({
             {
                 text: "Getting Started",
                 items: [
-                    { text: 'Installation', link: '/installation' },
+                    { text: 'Installation', link: '/installation.html' },
                     { text: 'Release Notes', link: '/releases.html' },
                     { text: 'Upgrade Guide', link: '/upgrade.html' },
                     { text: 'Support & Bug Reports', link: '/support.html' },


### PR DESCRIPTION
Think this one was missed from https://github.com/laravel/nova-docs/commit/d5e86f227e1568aa7dabe2a13de128ef8abc2b6b

Oh Dear also indicated this as a broken link.