### PR TITLE
Replace deprecated download() function with new downloadURL() function

### DIFF
--- a/src/actions/defining-actions.md
+++ b/src/actions/defining-actions.md
@@ -245,10 +245,10 @@ return Action::openInNewTab('https://example.com');
 
 ### Download Responses
 
-To initiate a file download after the action is executed, you may use the `Action::download` method. The `download` method accepts the URL of the file to be downloaded as its first argument, and the desired name of the file as its second argument:
+To initiate a file download after the action is executed, you may use the `Action::downloadURL` method. The `downloadURL` method accepts the URL of the file to be downloaded as its first argument, and the desired name of the file as its second argument:
 
 ```php
-return Action::download('https://example.com/invoice.pdf', 'Invoice.pdf');
+return Action::downloadURL('https://example.com/invoice.pdf', 'Invoice.pdf');
 ```
 
 ### Custom Modal Responses


### PR DESCRIPTION
The documentation for defining actions uses the deprecated ``download()`` method. Replaced it with the new ``downloadURL()`` method.

_The registering actions documentation already has the new ``downloadURL()``, so this change is only needed for the defining page._