### PR TITLE
Use `legacy.inertiajs.com` insteads of `inertiajs.com`

### DIFF
--- a/src/customization/frontend.md
+++ b/src/customization/frontend.md
@@ -26,7 +26,7 @@ Nova.visit(`/resources/users/${userId}`)
 Nova.visit({ url: 'https://nova.laravel.com', remote: true })
 ```
 
-The `visit` method accepts an array of navigation options as its second argument. As the `visit` method uses Inertia's own `visit` method behind the scenes, all of [Inertia's `visit` options](https://inertiajs.com/manual-visits) are supported by Nova's `visit` method:
+The `visit` method accepts an array of navigation options as its second argument. As the `visit` method uses Inertia's own `visit` method behind the scenes, all of [Inertia's `visit` options](https://legacy.inertiajs.com/manual-visits) are supported by Nova's `visit` method:
 
 ```js
 Nova.visit(`/resources/users/${userId}`, {

--- a/src/customization/tools.md
+++ b/src/customization/tools.md
@@ -70,7 +70,7 @@ The tool's service provider is also located within the `src` directory of the to
 
 Often, you will need to define Laravel routes that are called by your tool. When Nova generates your tool, it creates `routes/inertia.php` and `routes/api.php` route files.
 
-The `routes/inertia.php` file is tasked with rendering your tool via [Inertia](https://inertiajs.com), while the `routes/api.php` file may be used to define any routes that your Inertia based tool will be making requests to in order to gather additional data or perform additional tasks.
+The `routes/inertia.php` file is tasked with rendering your tool via [Inertia](https://legacy.inertiajs.com), while the `routes/api.php` file may be used to define any routes that your Inertia based tool will be making requests to in order to gather additional data or perform additional tasks.
 
 All routes within the `routes/api.php` file are automatically defined inside a route group by your tool's `ToolServiceProvider`. The route group specifies that all "API routes", which will typically be invoked from the client via [Nova.request](./frontend.md#nova-requests), should receive a `/nova-vendor/tool-name` URL prefix, where `tool-name` is the "kebab-case" name of your tool.
 

--- a/src/upgrade.md
+++ b/src/upgrade.md
@@ -281,7 +281,7 @@ mix
 
 **This change primarily affects the installation of custom tools that utilize Vue routing.**
 
-Nova 4 has replaced Vue router with [Inertia.js](https://inertiajs.com). Therefore, custom tools should migrate from registering Vue routes to registering Inertia.js page components and backend routes. For example, given the following Nova 3 Vue router registration:
+Nova 4 has replaced Vue router with [Inertia.js](https://legacy.inertiajs.com). Therefore, custom tools should migrate from registering Vue routes to registering Inertia.js page components and backend routes. For example, given the following Nova 3 Vue router registration:
 
 ```js
 // Within tool.js...


### PR DESCRIPTION
Laravel Nova 4 still rely on Inertia.JS for Vue 3 version `0.x`