### PR TITLE
Tailwind Compliant Classes

### DIFF
--- a/src/customization/fields.md
+++ b/src/customization/fields.md
@@ -111,7 +111,7 @@ Finally, Nova creates a `resources/js/components/FormField.vue` Vue component. T
                 v-model="value"
             />
 
-            <p v-if="hasError" class="my-2 text-danger">
+            <p v-if="hasError" class="my-2 text-red-500">
                 {{ firstError }}
             </p>
         </template>
@@ -181,7 +181,7 @@ Next, within your Vue template, you should typically refer to your field using `
         v-model="value"
       />
 
-      <p v-if="hasError" class="my-2 text-danger">
+      <p v-if="hasError" class="my-2 text-red-500">
         {{ firstError }}
       </p>
     </template>

--- a/src/resources/fields.md
+++ b/src/resources/fields.md
@@ -745,7 +745,7 @@ Heading::make('Meta'),
 If you need to render HTML content within the `Heading` field, you may invoke the `asHtml` method when defining the field:
 
 ```php
-Heading::make('<p class="text-danger">* All fields are required.</p>')->asHtml(),
+Heading::make('<p class="text-red-500">* All fields are required.</p>')->asHtml(),
 ```
 
 ::: tip Headings & The Index Page


### PR DESCRIPTION
There were three occurrences of `text-danger` classes in the example code within the Nova documentation. `text-danger` is not in the compiled CSS and has no impact. This PR updates them to the Tailwind CSS compliant class `text-red-500`.